### PR TITLE
Migrate Ipamer to a interface

### DIFF
--- a/ipam.go
+++ b/ipam.go
@@ -28,9 +28,6 @@ type Ipamer interface {
 	// PrefixesOverlapping will check if one ore more prefix of newPrefixes is overlapping
 	// with one of existingPrefixes
 	PrefixesOverlapping(existingPrefixes []string, newPrefixes []string) error
-	// GetHostAddresses will return all possible ipadresses a host can get in the given prefix.
-	// The IPs will be acquired by this method, so that the prefix has no free IPs afterwards.
-	GetHostAddresses(prefix string) ([]string, error)
 }
 
 type ipamer struct {

--- a/ipam.go
+++ b/ipam.go
@@ -1,18 +1,50 @@
 package ipam
 
 // Ipamer can be used to do IPAM stuff.
-type Ipamer struct {
+type Ipamer interface {
+	// NewPrefix create a new Prefix from a string notation.
+	NewPrefix(cidr string) (*Prefix, error)
+	// DeletePrefix delete a Prefix from a string notation.
+	// If the Prefix is not found an NotFoundError is returned.
+	DeletePrefix(cidr string) (*Prefix, error)
+	// AcquireChildPrefix will return a Prefix with a smaller length from the given Prefix.
+	AcquireChildPrefix(parentCidr string, length int) (*Prefix, error)
+	// ReleaseChildPrefix will mark this child Prefix as available again.
+	ReleaseChildPrefix(child *Prefix) error
+	// PrefixFrom will return a known Prefix.
+	PrefixFrom(cidr string) *Prefix
+	// AcquireSpecificIP will acquire given IP and mark this IP as used, if already in use, return nil.
+	// If specificIP is empty, the next free IP is returned.
+	// If there is no free IP an NoIPAvailableError is returned.
+	AcquireSpecificIP(prefixCidr, specificIP string) (*IP, error)
+	// AcquireIP will return the next unused IP from this Prefix.
+	AcquireIP(prefixCidr string) (*IP, error)
+	// ReleaseIP will release the given IP for later usage and returns the updated Prefix.
+	// If the IP is not found an NotFoundError is returned.
+	ReleaseIP(ip *IP) (*Prefix, error)
+	// ReleaseIPFromPrefix will release the given IP for later usage.
+	// If the Prefix or the IP is not found an NotFoundError is returned.
+	ReleaseIPFromPrefix(prefixCidr, ip string) error
+	// PrefixesOverlapping will check if one ore more prefix of newPrefixes is overlapping
+	// with one of existingPrefixes
+	PrefixesOverlapping(existingPrefixes []string, newPrefixes []string) error
+	// GetHostAddresses will return all possible ipadresses a host can get in the given prefix.
+	// The IPs will be acquired by this method, so that the prefix has no free IPs afterwards.
+	GetHostAddresses(prefix string) ([]string, error)
+}
+
+type ipamer struct {
 	storage Storage
 }
 
 // New returns a Ipamer with in memory storage for networks, prefixes and ips.
-func New() *Ipamer {
+func New() Ipamer {
 	storage := NewMemory()
-	return &Ipamer{storage: storage}
+	return &ipamer{storage: storage}
 }
 
 // NewWithStorage allows you to create a Ipamer instance with your Storage implementation.
 // The Storage interface must be implemented.
-func NewWithStorage(storage Storage) *Ipamer {
-	return &Ipamer{storage: storage}
+func NewWithStorage(storage Storage) Ipamer {
+	return &ipamer{storage: storage}
 }

--- a/ipam_test.go
+++ b/ipam_test.go
@@ -2,23 +2,7 @@ package ipam
 
 import (
 	"fmt"
-	"testing"
-
-	"github.com/stretchr/testify/require"
 )
-
-func Test_NewWithStorage(t *testing.T) {
-	storage := NewMemory()
-	ipamer := NewWithStorage(storage)
-	require.NotNil(t, ipamer)
-	require.Equal(t, storage, ipamer.storage)
-}
-
-func Test_New(t *testing.T) {
-	ipamer := New()
-	require.NotNil(t, ipamer)
-	require.NotNil(t, ipamer.storage)
-}
 
 func ExampleIpamer_NewPrefix() {
 	ipamer := New()

--- a/prefix.go
+++ b/prefix.go
@@ -12,7 +12,9 @@ import (
 )
 
 var (
-	ErrNotFound      NotFoundError
+	// ErrNotFound is returned if prefix or cidr was not found
+	ErrNotFound NotFoundError
+	// ErrNoIPAvailable is returned if no IP is available anymore
 	ErrNoIPAvailable NoIPAvailableError
 )
 
@@ -54,8 +56,7 @@ type Usage struct {
 	AcquiredPrefixes  uint64
 }
 
-// NewPrefix create a new Prefix from a string notation.
-func (i *Ipamer) NewPrefix(cidr string) (*Prefix, error) {
+func (i *ipamer) NewPrefix(cidr string) (*Prefix, error) {
 	p, err := i.newPrefix(cidr)
 	if err != nil {
 		return nil, err
@@ -68,9 +69,7 @@ func (i *Ipamer) NewPrefix(cidr string) (*Prefix, error) {
 	return &newPrefix, nil
 }
 
-// DeletePrefix delete a Prefix from a string notation.
-// If the Prefix is not found an NotFoundError is returned.
-func (i *Ipamer) DeletePrefix(cidr string) (*Prefix, error) {
+func (i *ipamer) DeletePrefix(cidr string) (*Prefix, error) {
 	p := i.PrefixFrom(cidr)
 	if p == nil {
 		return nil, fmt.Errorf("%w: delete prefix:%s", ErrNotFound, cidr)
@@ -86,8 +85,7 @@ func (i *Ipamer) DeletePrefix(cidr string) (*Prefix, error) {
 	return &prefix, nil
 }
 
-// AcquireChildPrefix will return a Prefix with a smaller length from the given Prefix.
-func (i *Ipamer) AcquireChildPrefix(parentCidr string, length int) (*Prefix, error) {
+func (i *ipamer) AcquireChildPrefix(parentCidr string, length int) (*Prefix, error) {
 	var prefix *Prefix
 	return prefix, retryOnOptimisticLock(func() error {
 		var err error
@@ -98,7 +96,7 @@ func (i *Ipamer) AcquireChildPrefix(parentCidr string, length int) (*Prefix, err
 
 // acquireChildPrefixInternal will return a Prefix with a smaller length from the given Prefix.
 // FIXME allow variable child prefix length
-func (i *Ipamer) acquireChildPrefixInternal(parentCidr string, length int) (*Prefix, error) {
+func (i *ipamer) acquireChildPrefixInternal(parentCidr string, length int) (*Prefix, error) {
 	prefix := i.PrefixFrom(parentCidr)
 	if prefix == nil {
 		return nil, fmt.Errorf("unable to find prefix for cidr:%s", parentCidr)
@@ -179,15 +177,14 @@ func (i *Ipamer) acquireChildPrefixInternal(parentCidr string, length int) (*Pre
 	return child, nil
 }
 
-// ReleaseChildPrefix will mark this child Prefix as available again.
-func (i *Ipamer) ReleaseChildPrefix(child *Prefix) error {
+func (i *ipamer) ReleaseChildPrefix(child *Prefix) error {
 	return retryOnOptimisticLock(func() error {
 		return i.releaseChildPrefixInternal(child)
 	})
 }
 
 // releaseChildPrefixInternal will mark this child Prefix as available again.
-func (i *Ipamer) releaseChildPrefixInternal(child *Prefix) error {
+func (i *ipamer) releaseChildPrefixInternal(child *Prefix) error {
 	parent := i.PrefixFrom(child.ParentCidr)
 
 	if parent == nil {
@@ -209,8 +206,7 @@ func (i *Ipamer) releaseChildPrefixInternal(child *Prefix) error {
 	return nil
 }
 
-// PrefixFrom will return a known Prefix.
-func (i *Ipamer) PrefixFrom(cidr string) *Prefix {
+func (i *ipamer) PrefixFrom(cidr string) *Prefix {
 	prefix, err := i.storage.ReadPrefix(cidr)
 	if err != nil {
 		return nil
@@ -218,10 +214,7 @@ func (i *Ipamer) PrefixFrom(cidr string) *Prefix {
 	return &prefix
 }
 
-// AcquireSpecificIP will acquire given IP and mark this IP as used, if already in use, return nil.
-// If specificIP is empty, the next free IP is returned.
-// If there is no free IP an NoIPAvailableError is returned.
-func (i *Ipamer) AcquireSpecificIP(prefixCidr, specificIP string) (*IP, error) {
+func (i *ipamer) AcquireSpecificIP(prefixCidr, specificIP string) (*IP, error) {
 	var ip *IP
 	return ip, retryOnOptimisticLock(func() error {
 		var err error
@@ -234,7 +227,7 @@ func (i *Ipamer) AcquireSpecificIP(prefixCidr, specificIP string) (*IP, error) {
 // If specificIP is empty, the next free IP is returned.
 // If there is no free IP an NoIPAvailableError is returned.
 // If the Prefix is not found an NotFoundError is returned.
-func (i *Ipamer) acquireSpecificIPInternal(prefixCidr, specificIP string) (*IP, error) {
+func (i *ipamer) acquireSpecificIPInternal(prefixCidr, specificIP string) (*IP, error) {
 	prefix := i.PrefixFrom(prefixCidr)
 	if prefix == nil {
 		return nil, fmt.Errorf("%w: unable to find prefix for cidr:%s", ErrNotFound, prefixCidr)
@@ -284,29 +277,24 @@ func (i *Ipamer) acquireSpecificIPInternal(prefixCidr, specificIP string) (*IP, 
 	return nil, fmt.Errorf("%w: no more ips in prefix: %s left, length of prefix.ips: %d", ErrNoIPAvailable, prefix.Cidr, len(prefix.ips))
 }
 
-// AcquireIP will return the next unused IP from this Prefix.
-func (i *Ipamer) AcquireIP(prefixCidr string) (*IP, error) {
+func (i *ipamer) AcquireIP(prefixCidr string) (*IP, error) {
 	return i.AcquireSpecificIP(prefixCidr, "")
 }
 
-// ReleaseIP will release the given IP for later usage and returns the updated Prefix.
-// If the IP is not found an NotFoundError is returned.
-func (i *Ipamer) ReleaseIP(ip *IP) (*Prefix, error) {
+func (i *ipamer) ReleaseIP(ip *IP) (*Prefix, error) {
 	err := i.ReleaseIPFromPrefix(ip.ParentPrefix, ip.IP.String())
 	prefix := i.PrefixFrom(ip.ParentPrefix)
 	return prefix, err
 }
 
-// ReleaseIPFromPrefix will release the given IP for later usage.
-// If the Prefix or the IP is not found an NotFoundError is returned.
-func (i *Ipamer) ReleaseIPFromPrefix(prefixCidr, ip string) error {
+func (i *ipamer) ReleaseIPFromPrefix(prefixCidr, ip string) error {
 	return retryOnOptimisticLock(func() error {
 		return i.releaseIPFromPrefixInternal(prefixCidr, ip)
 	})
 }
 
 // releaseIPFromPrefixInternal will release the given IP for later usage.
-func (i *Ipamer) releaseIPFromPrefixInternal(prefixCidr, ip string) error {
+func (i *ipamer) releaseIPFromPrefixInternal(prefixCidr, ip string) error {
 	prefix := i.PrefixFrom(prefixCidr)
 	if prefix == nil {
 		return fmt.Errorf("%w: unable to find prefix for cidr:%s", ErrNotFound, prefixCidr)
@@ -323,9 +311,7 @@ func (i *Ipamer) releaseIPFromPrefixInternal(prefixCidr, ip string) error {
 	return nil
 }
 
-// PrefixesOverlapping will check if one ore more prefix of newPrefixes is overlapping
-// with one of existingPrefixes
-func (i *Ipamer) PrefixesOverlapping(existingPrefixes []string, newPrefixes []string) error {
+func (i *ipamer) PrefixesOverlapping(existingPrefixes []string, newPrefixes []string) error {
 	for _, ep := range existingPrefixes {
 		eip, eipnet, err := net.ParseCIDR(ep)
 		if err != nil {
@@ -345,9 +331,7 @@ func (i *Ipamer) PrefixesOverlapping(existingPrefixes []string, newPrefixes []st
 	return nil
 }
 
-// GetHostAddresses will return all possible ipadresses a host can get in the given prefix.
-// The IPs will be acquired by this method, so that the prefix has no free IPs afterwards.
-func (i *Ipamer) GetHostAddresses(prefix string) ([]string, error) {
+func (i *ipamer) GetHostAddresses(prefix string) ([]string, error) {
 	hostAddresses := []string{}
 
 	p, err := i.NewPrefix(prefix)
@@ -368,8 +352,8 @@ func (i *Ipamer) GetHostAddresses(prefix string) ([]string, error) {
 	}
 }
 
-// NewPrefix create a new Prefix from a string notation.
-func (i *Ipamer) newPrefix(cidr string) (*Prefix, error) {
+// newPrefix create a new Prefix from a string notation.
+func (i *ipamer) newPrefix(cidr string) (*Prefix, error) {
 	_, _, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse cidr:%s %v", cidr, err)
@@ -438,7 +422,7 @@ func (p *Prefix) Network() (net.IP, error) {
 	return ip.Mask(ipnet.Mask), nil
 }
 
-// Availableips return the number of ips available in this Prefix
+// availableips return the number of ips available in this Prefix
 func (p *Prefix) availableips() uint64 {
 	_, ipnet, err := net.ParseCIDR(p.Cidr)
 	if err != nil {
@@ -457,17 +441,17 @@ func (p *Prefix) availableips() uint64 {
 	return count
 }
 
-// Acquiredips return the number of ips acquired in this Prefix
+// acquiredips return the number of ips acquired in this Prefix
 func (p *Prefix) acquiredips() uint64 {
 	return uint64(len(p.ips))
 }
 
-// AvailablePrefixes return the amount of possible prefixes of this prefix if this is a parent prefix
+// availablePrefixes return the amount of possible prefixes of this prefix if this is a parent prefix
 func (p *Prefix) availablePrefixes() uint64 {
 	return uint64(len(p.availableChildPrefixes))
 }
 
-// AcquiredPrefixes return the amount of acquired prefixes of this prefix if this is a parent prefix
+// acquiredPrefixes return the amount of acquired prefixes of this prefix if this is a parent prefix
 func (p *Prefix) acquiredPrefixes() uint64 {
 	var count uint64
 	for _, available := range p.availableChildPrefixes {

--- a/prefix.go
+++ b/prefix.go
@@ -331,7 +331,9 @@ func (i *ipamer) PrefixesOverlapping(existingPrefixes []string, newPrefixes []st
 	return nil
 }
 
-func (i *ipamer) GetHostAddresses(prefix string) ([]string, error) {
+// getHostAddresses will return all possible ipadresses a host can get in the given prefix.
+// The IPs will be acquired by this method, so that the prefix has no free IPs afterwards.
+func (i *ipamer) getHostAddresses(prefix string) ([]string, error) {
 	hostAddresses := []string{}
 
 	p, err := i.NewPrefix(prefix)

--- a/prefix_benchmark_test.go
+++ b/prefix_benchmark_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func benchmarkNewPrefix(ipam *Ipamer, b *testing.B) {
+func benchmarkNewPrefix(ipam Ipamer, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		p, err := ipam.NewPrefix("192.168.0.0/24")
 		if err != nil {
@@ -34,7 +34,7 @@ func BenchmarkNewPrefixPostgres(b *testing.B) {
 	benchmarkNewPrefix(ipam, b)
 }
 
-func benchmarkAcquireIP(ipam *Ipamer, cidr string, b *testing.B) {
+func benchmarkAcquireIP(ipam Ipamer, cidr string, b *testing.B) {
 	p, err := ipam.NewPrefix(cidr)
 	if err != nil {
 		panic(err)

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -617,7 +617,7 @@ func TestIpamerAcquireIP(t *testing.T) {
 func TestGetHostAddresses(t *testing.T) {
 	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		cidr := "4.1.0.0/24"
-		ips, err := ipam.GetHostAddresses(cidr)
+		ips, err := ipam.getHostAddresses(cidr)
 		if err != nil {
 			panic(err)
 		}
@@ -632,7 +632,7 @@ func TestGetHostAddresses(t *testing.T) {
 		require.Nil(t, ip)
 
 		cidr = "3.1.0.0/26"
-		ips, err = ipam.GetHostAddresses(cidr)
+		ips, err = ipam.getHostAddresses(cidr)
 		if err != nil {
 			panic(err)
 		}

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -55,7 +55,7 @@ func TestIpamer_AcquireIP(t *testing.T) {
 	}
 	for _, tt := range tests {
 
-		testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+		testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 			p, err := ipam.NewPrefix(tt.fields.prefixCIDR)
 			if err != nil {
 				t.Errorf("Could not create prefix: %v", err)
@@ -85,7 +85,7 @@ func TestIpamer_AcquireIP(t *testing.T) {
 
 func TestIpamer_ReleaseIPFromPrefix(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/24")
 		require.Nil(t, err)
 		require.NotNil(t, prefix)
@@ -105,7 +105,7 @@ func TestIpamer_ReleaseIPFromPrefix(t *testing.T) {
 }
 
 func TestIpamer_AcquireSpecificIP(t *testing.T) {
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.99.0/24")
 		require.Nil(t, err)
 		require.Equal(t, prefix.availableips(), uint64(256))
@@ -160,7 +160,7 @@ func TestIpamer_AcquireSpecificIP(t *testing.T) {
 
 func TestIpamer_AcquireIPCounts(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/24")
 		require.Nil(t, err)
 		require.Equal(t, prefix.availableips(), uint64(256))
@@ -195,7 +195,7 @@ func TestIpamer_AcquireIPCounts(t *testing.T) {
 
 func TestIpamer_AcquireChildPrefixCounts(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		allPrefixes, err := ipam.storage.ReadAllPrefixes()
 		require.Nil(t, err)
 		require.Equal(t, 0, len(allPrefixes))
@@ -292,7 +292,7 @@ func TestIpamer_AcquireChildPrefixCounts(t *testing.T) {
 
 func TestIpamer_AcquireChildPrefix(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/20")
 		require.Nil(t, err)
 		require.Equal(t, prefix.availablePrefixes(), uint64(0))
@@ -363,7 +363,7 @@ func TestIpamer_AcquireChildPrefix(t *testing.T) {
 
 func TestIpamer_AcquireChildPrefixNoDuplicatesUntilFull(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/16")
 		require.Nil(t, err)
 		require.Equal(t, uint64(0), prefix.availablePrefixes())
@@ -481,7 +481,7 @@ func TestIpamer_PrefixesOverlapping(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+		testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 			for _, ep := range tt.existingPrefixes {
 				p, err := ipam.NewPrefix(ep)
 				if err != nil {
@@ -527,7 +527,7 @@ func TestIpamer_NewPrefix(t *testing.T) {
 	}
 	for _, tt := range tests {
 
-		testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+		testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 			got, err := ipam.NewPrefix(tt.cidr)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Ipamer.NewPrefix() error = %v, wantErr %v", err, tt.wantErr)
@@ -551,7 +551,7 @@ func TestIpamer_NewPrefix(t *testing.T) {
 
 func TestIpamer_DeletePrefix(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/20")
 		require.Nil(t, err)
 		require.Equal(t, prefix.availablePrefixes(), uint64(0))
@@ -570,7 +570,7 @@ func TestIpamer_DeletePrefix(t *testing.T) {
 
 func TestIpamer_PrefixFrom(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix := ipam.PrefixFrom("192.168.0.0/20")
 		require.Nil(t, prefix)
 
@@ -585,7 +585,7 @@ func TestIpamer_PrefixFrom(t *testing.T) {
 
 func TestIpamerAcquireIP(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		cidr := "10.0.0.0/16"
 		p, err := ipam.NewPrefix(cidr)
 		if err != nil {
@@ -615,7 +615,7 @@ func TestIpamerAcquireIP(t *testing.T) {
 }
 
 func TestGetHostAddresses(t *testing.T) {
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		cidr := "4.1.0.0/24"
 		ips, err := ipam.GetHostAddresses(cidr)
 		if err != nil {
@@ -708,7 +708,7 @@ func (e *ExtendedSQL) cleanup() error {
 	return tx.Commit()
 }
 
-type testMethod func(t *testing.T, ipam *Ipamer)
+type testMethod func(t *testing.T, ipam *ipamer)
 
 func testWithBackends(t *testing.T, fn testMethod) {
 	for _, storageProvider := range storageProviders() {
@@ -722,7 +722,8 @@ func testWithBackends(t *testing.T, fn testMethod) {
 			}
 		}
 
-		ipamer := NewWithStorage(storage)
+		//ipamer := NewWithStorage(storage)
+		ipamer := &ipamer{storage: storage}
 		testName := storageProvider.name
 
 		t.Run(testName, func(t *testing.T) {


### PR DESCRIPTION
I am in the process of implementing #23 and #25 but found the current interface not obvious.

So lets start extracting Ipam as an interface, this will break existing user, because no pointer receiver anymore, but makes further development easier