### PR TITLE
RFC: Namespaced prefixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/avast/retry-go v2.6.0+incompatible
+	github.com/google/uuid v1.1.1
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.5.2
 	// sqlite v2.x is a unfortunate release

--- a/ip.go
+++ b/ip.go
@@ -10,6 +10,7 @@ import (
 type IP struct {
 	IP           net.IP
 	ParentPrefix string
+	UUID         string
 }
 
 func (i *IP) or(ip IP) IP {

--- a/ipam.go
+++ b/ipam.go
@@ -28,9 +28,6 @@ type Ipamer interface {
 	// PrefixesOverlapping will check if one ore more prefix of newPrefixes is overlapping
 	// with one of existingPrefixes
 	PrefixesOverlapping(existingPrefixes []string, newPrefixes []string) error
-	// GetHostAddresses will return all possible ipadresses a host can get in the given prefix.
-	// The IPs will be acquired by this method, so that the prefix has no free IPs afterwards.
-	GetHostAddresses(prefix string) ([]string, error)
 }
 
 type ipamer struct {

--- a/ipam.go
+++ b/ipam.go
@@ -1,18 +1,50 @@
 package ipam
 
 // Ipamer can be used to do IPAM stuff.
-type Ipamer struct {
+type Ipamer interface {
+	// NewPrefix create a new Prefix from a string notation.
+	NewPrefix(cidr string) (*Prefix, error)
+	// DeletePrefix delete a Prefix from a string notation.
+	// If the Prefix is not found an NotFoundError is returned.
+	DeletePrefix(cidr string) (*Prefix, error)
+	// AcquireChildPrefix will return a Prefix with a smaller length from the given Prefix.
+	AcquireChildPrefix(parentCidr string, length int) (*Prefix, error)
+	// ReleaseChildPrefix will mark this child Prefix as available again.
+	ReleaseChildPrefix(child *Prefix) error
+	// PrefixFrom will return a known Prefix.
+	PrefixFrom(cidr string) *Prefix
+	// AcquireSpecificIP will acquire given IP and mark this IP as used, if already in use, return nil.
+	// If specificIP is empty, the next free IP is returned.
+	// If there is no free IP an NoIPAvailableError is returned.
+	AcquireSpecificIP(prefixCidr, specificIP string) (*IP, error)
+	// AcquireIP will return the next unused IP from this Prefix.
+	AcquireIP(prefixCidr string) (*IP, error)
+	// ReleaseIP will release the given IP for later usage and returns the updated Prefix.
+	// If the IP is not found an NotFoundError is returned.
+	ReleaseIP(ip *IP) (*Prefix, error)
+	// ReleaseIPFromPrefix will release the given IP for later usage.
+	// If the Prefix or the IP is not found an NotFoundError is returned.
+	ReleaseIPFromPrefix(prefixCidr, ip string) error
+	// PrefixesOverlapping will check if one ore more prefix of newPrefixes is overlapping
+	// with one of existingPrefixes
+	PrefixesOverlapping(existingPrefixes []string, newPrefixes []string) error
+	// GetHostAddresses will return all possible ipadresses a host can get in the given prefix.
+	// The IPs will be acquired by this method, so that the prefix has no free IPs afterwards.
+	GetHostAddresses(prefix string) ([]string, error)
+}
+
+type ipamer struct {
 	storage Storage
 }
 
 // New returns a Ipamer with in memory storage for networks, prefixes and ips.
-func New() *Ipamer {
+func New() Ipamer {
 	storage := NewMemory()
-	return &Ipamer{storage: storage}
+	return &ipamer{storage: storage}
 }
 
 // NewWithStorage allows you to create a Ipamer instance with your Storage implementation.
 // The Storage interface must be implemented.
-func NewWithStorage(storage Storage) *Ipamer {
-	return &Ipamer{storage: storage}
+func NewWithStorage(storage Storage) Ipamer {
+	return &ipamer{storage: storage}
 }

--- a/ipam.go
+++ b/ipam.go
@@ -30,8 +30,15 @@ type Ipamer interface {
 	PrefixesOverlapping(existingPrefixes []string, newPrefixes []string) error
 }
 
+// NamespacedIpamer will create Prefixes seperated in Namespaces.
+// This is useful for scenarios where you want to create overlapping Networks and IPs
+type NamespacedIpamer interface {
+	Ipamer
+}
+
 type ipamer struct {
-	storage Storage
+	storage   Storage
+	namespace *string
 }
 
 // New returns a Ipamer with in memory storage for networks, prefixes and ips.
@@ -44,4 +51,22 @@ func New() Ipamer {
 // The Storage interface must be implemented.
 func NewWithStorage(storage Storage) Ipamer {
 	return &ipamer{storage: storage}
+}
+
+// NewNamespaced returns a Ipamer with in memory storage for networks, prefixes and ips.
+func NewNamespaced(namespace *string) Ipamer {
+	storage := NewMemory()
+	return &ipamer{
+		storage:   storage,
+		namespace: namespace,
+	}
+}
+
+// NewNamespacedWithStorage allows you to create a Ipamer instance with your Storage implementation.
+// The Storage interface must be implemented.
+func NewNamespacedWithStorage(namespace *string, storage Storage) Ipamer {
+	return &ipamer{
+		storage:   storage,
+		namespace: namespace,
+	}
 }

--- a/ipam_test.go
+++ b/ipam_test.go
@@ -2,23 +2,7 @@ package ipam
 
 import (
 	"fmt"
-	"testing"
-
-	"github.com/stretchr/testify/require"
 )
-
-func Test_NewWithStorage(t *testing.T) {
-	storage := NewMemory()
-	ipamer := NewWithStorage(storage)
-	require.NotNil(t, ipamer)
-	require.Equal(t, storage, ipamer.storage)
-}
-
-func Test_New(t *testing.T) {
-	ipamer := New()
-	require.NotNil(t, ipamer)
-	require.NotNil(t, ipamer.storage)
-}
 
 func ExampleIpamer_NewPrefix() {
 	ipamer := New()

--- a/memory_test.go
+++ b/memory_test.go
@@ -11,17 +11,17 @@ func Test_ReadPrefix(t *testing.T) {
 	m := NewMemory()
 
 	// Prefix
-	p, err := m.ReadPrefix("12.0.0.0/8")
+	p, err := m.ReadPrefix(nil, "12.0.0.0/8")
 	require.NotNil(t, err)
 	require.Equal(t, "Prefix 12.0.0.0/8 not found", err.Error())
 	require.Empty(t, p)
 
 	prefix := Prefix{Cidr: "12.0.0.0/16"}
-	p, err = m.CreatePrefix(prefix)
+	p, err = m.CreatePrefix(nil, prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
 
-	p, err = m.ReadPrefix("12.0.0.0/16")
+	p, err = m.ReadPrefix(nil, "12.0.0.0/16")
 	require.Nil(t, err)
 	require.NotNil(t, p)
 	require.Equal(t, "12.0.0.0/16", p.Cidr)
@@ -31,13 +31,13 @@ func Test_UpdatePrefix(t *testing.T) {
 	m := NewMemory()
 
 	prefix := Prefix{}
-	p, err := m.UpdatePrefix(prefix)
+	p, err := m.UpdatePrefix(nil, prefix)
 	require.NotNil(t, err)
 	require.Empty(t, p)
-	require.Equal(t, "prefix not present:{  map[] 0 map[] 0}", err.Error())
+	require.Equal(t, "prefix not present:{  map[] 0 map[] 0 }", err.Error())
 
 	prefix.Cidr = "1.2.3.4/24"
-	p, err = m.UpdatePrefix(prefix)
+	p, err = m.UpdatePrefix(nil, prefix)
 	require.NotNil(t, err)
 	require.Empty(t, p)
 	require.Equal(t, "prefix not found:1.2.3.4/24", err.Error())
@@ -54,23 +54,23 @@ func Test_UpdatePrefix_Concurrent(t *testing.T) {
 			cidr := calcPrefix24(run) + "/24"
 			prefix.Cidr = cidr
 
-			p, err := m.CreatePrefix(prefix)
+			p, err := m.CreatePrefix(nil, prefix)
 			require.Nil(t, err)
 			require.NotNil(t, p)
 
-			p, err = m.ReadPrefix(cidr)
+			p, err = m.ReadPrefix(nil, cidr)
 			require.Nil(t, err)
 			require.NotNil(t, p)
 
-			p, err = m.UpdatePrefix(p)
+			p, err = m.UpdatePrefix(nil, p)
 			require.Nil(t, err)
 			require.NotNil(t, p)
 
-			p, err = m.ReadPrefix(cidr)
+			p, err = m.ReadPrefix(nil, cidr)
 			require.Nil(t, err)
 			require.NotNil(t, p)
 
-			p, err = m.DeletePrefix(p)
+			p, err = m.DeletePrefix(nil, p)
 			require.Nil(t, err)
 			require.NotNil(t, p)
 		}(i)

--- a/prefix.go
+++ b/prefix.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -266,6 +267,7 @@ func (i *ipamer) acquireSpecificIPInternal(prefixCidr, specificIP string) (*IP, 
 			acquired = &IP{
 				IP:           ip,
 				ParentPrefix: prefix.Cidr,
+				UUID:         uuid.New().String(),
 			}
 			prefix.ips[ip.String()] = true
 			_, err := i.storage.UpdatePrefix(i.namespace, *prefix)

--- a/prefix.go
+++ b/prefix.go
@@ -12,7 +12,9 @@ import (
 )
 
 var (
-	ErrNotFound      NotFoundError
+	// ErrNotFound is returned if prefix or cidr was not found
+	ErrNotFound NotFoundError
+	// ErrNoIPAvailable is returned if no IP is available anymore
 	ErrNoIPAvailable NoIPAvailableError
 )
 
@@ -54,8 +56,7 @@ type Usage struct {
 	AcquiredPrefixes  uint64
 }
 
-// NewPrefix create a new Prefix from a string notation.
-func (i *Ipamer) NewPrefix(cidr string) (*Prefix, error) {
+func (i *ipamer) NewPrefix(cidr string) (*Prefix, error) {
 	p, err := i.newPrefix(cidr)
 	if err != nil {
 		return nil, err
@@ -68,9 +69,7 @@ func (i *Ipamer) NewPrefix(cidr string) (*Prefix, error) {
 	return &newPrefix, nil
 }
 
-// DeletePrefix delete a Prefix from a string notation.
-// If the Prefix is not found an NotFoundError is returned.
-func (i *Ipamer) DeletePrefix(cidr string) (*Prefix, error) {
+func (i *ipamer) DeletePrefix(cidr string) (*Prefix, error) {
 	p := i.PrefixFrom(cidr)
 	if p == nil {
 		return nil, fmt.Errorf("%w: delete prefix:%s", ErrNotFound, cidr)
@@ -86,8 +85,7 @@ func (i *Ipamer) DeletePrefix(cidr string) (*Prefix, error) {
 	return &prefix, nil
 }
 
-// AcquireChildPrefix will return a Prefix with a smaller length from the given Prefix.
-func (i *Ipamer) AcquireChildPrefix(parentCidr string, length int) (*Prefix, error) {
+func (i *ipamer) AcquireChildPrefix(parentCidr string, length int) (*Prefix, error) {
 	var prefix *Prefix
 	return prefix, retryOnOptimisticLock(func() error {
 		var err error
@@ -98,7 +96,7 @@ func (i *Ipamer) AcquireChildPrefix(parentCidr string, length int) (*Prefix, err
 
 // acquireChildPrefixInternal will return a Prefix with a smaller length from the given Prefix.
 // FIXME allow variable child prefix length
-func (i *Ipamer) acquireChildPrefixInternal(parentCidr string, length int) (*Prefix, error) {
+func (i *ipamer) acquireChildPrefixInternal(parentCidr string, length int) (*Prefix, error) {
 	prefix := i.PrefixFrom(parentCidr)
 	if prefix == nil {
 		return nil, fmt.Errorf("unable to find prefix for cidr:%s", parentCidr)
@@ -179,15 +177,14 @@ func (i *Ipamer) acquireChildPrefixInternal(parentCidr string, length int) (*Pre
 	return child, nil
 }
 
-// ReleaseChildPrefix will mark this child Prefix as available again.
-func (i *Ipamer) ReleaseChildPrefix(child *Prefix) error {
+func (i *ipamer) ReleaseChildPrefix(child *Prefix) error {
 	return retryOnOptimisticLock(func() error {
 		return i.releaseChildPrefixInternal(child)
 	})
 }
 
 // releaseChildPrefixInternal will mark this child Prefix as available again.
-func (i *Ipamer) releaseChildPrefixInternal(child *Prefix) error {
+func (i *ipamer) releaseChildPrefixInternal(child *Prefix) error {
 	parent := i.PrefixFrom(child.ParentCidr)
 
 	if parent == nil {
@@ -209,8 +206,7 @@ func (i *Ipamer) releaseChildPrefixInternal(child *Prefix) error {
 	return nil
 }
 
-// PrefixFrom will return a known Prefix.
-func (i *Ipamer) PrefixFrom(cidr string) *Prefix {
+func (i *ipamer) PrefixFrom(cidr string) *Prefix {
 	prefix, err := i.storage.ReadPrefix(cidr)
 	if err != nil {
 		return nil
@@ -218,10 +214,7 @@ func (i *Ipamer) PrefixFrom(cidr string) *Prefix {
 	return &prefix
 }
 
-// AcquireSpecificIP will acquire given IP and mark this IP as used, if already in use, return nil.
-// If specificIP is empty, the next free IP is returned.
-// If there is no free IP an NoIPAvailableError is returned.
-func (i *Ipamer) AcquireSpecificIP(prefixCidr, specificIP string) (*IP, error) {
+func (i *ipamer) AcquireSpecificIP(prefixCidr, specificIP string) (*IP, error) {
 	var ip *IP
 	return ip, retryOnOptimisticLock(func() error {
 		var err error
@@ -234,7 +227,7 @@ func (i *Ipamer) AcquireSpecificIP(prefixCidr, specificIP string) (*IP, error) {
 // If specificIP is empty, the next free IP is returned.
 // If there is no free IP an NoIPAvailableError is returned.
 // If the Prefix is not found an NotFoundError is returned.
-func (i *Ipamer) acquireSpecificIPInternal(prefixCidr, specificIP string) (*IP, error) {
+func (i *ipamer) acquireSpecificIPInternal(prefixCidr, specificIP string) (*IP, error) {
 	prefix := i.PrefixFrom(prefixCidr)
 	if prefix == nil {
 		return nil, fmt.Errorf("%w: unable to find prefix for cidr:%s", ErrNotFound, prefixCidr)
@@ -284,29 +277,24 @@ func (i *Ipamer) acquireSpecificIPInternal(prefixCidr, specificIP string) (*IP, 
 	return nil, fmt.Errorf("%w: no more ips in prefix: %s left, length of prefix.ips: %d", ErrNoIPAvailable, prefix.Cidr, len(prefix.ips))
 }
 
-// AcquireIP will return the next unused IP from this Prefix.
-func (i *Ipamer) AcquireIP(prefixCidr string) (*IP, error) {
+func (i *ipamer) AcquireIP(prefixCidr string) (*IP, error) {
 	return i.AcquireSpecificIP(prefixCidr, "")
 }
 
-// ReleaseIP will release the given IP for later usage and returns the updated Prefix.
-// If the IP is not found an NotFoundError is returned.
-func (i *Ipamer) ReleaseIP(ip *IP) (*Prefix, error) {
+func (i *ipamer) ReleaseIP(ip *IP) (*Prefix, error) {
 	err := i.ReleaseIPFromPrefix(ip.ParentPrefix, ip.IP.String())
 	prefix := i.PrefixFrom(ip.ParentPrefix)
 	return prefix, err
 }
 
-// ReleaseIPFromPrefix will release the given IP for later usage.
-// If the Prefix or the IP is not found an NotFoundError is returned.
-func (i *Ipamer) ReleaseIPFromPrefix(prefixCidr, ip string) error {
+func (i *ipamer) ReleaseIPFromPrefix(prefixCidr, ip string) error {
 	return retryOnOptimisticLock(func() error {
 		return i.releaseIPFromPrefixInternal(prefixCidr, ip)
 	})
 }
 
 // releaseIPFromPrefixInternal will release the given IP for later usage.
-func (i *Ipamer) releaseIPFromPrefixInternal(prefixCidr, ip string) error {
+func (i *ipamer) releaseIPFromPrefixInternal(prefixCidr, ip string) error {
 	prefix := i.PrefixFrom(prefixCidr)
 	if prefix == nil {
 		return fmt.Errorf("%w: unable to find prefix for cidr:%s", ErrNotFound, prefixCidr)
@@ -323,9 +311,7 @@ func (i *Ipamer) releaseIPFromPrefixInternal(prefixCidr, ip string) error {
 	return nil
 }
 
-// PrefixesOverlapping will check if one ore more prefix of newPrefixes is overlapping
-// with one of existingPrefixes
-func (i *Ipamer) PrefixesOverlapping(existingPrefixes []string, newPrefixes []string) error {
+func (i *ipamer) PrefixesOverlapping(existingPrefixes []string, newPrefixes []string) error {
 	for _, ep := range existingPrefixes {
 		eip, eipnet, err := net.ParseCIDR(ep)
 		if err != nil {
@@ -345,9 +331,7 @@ func (i *Ipamer) PrefixesOverlapping(existingPrefixes []string, newPrefixes []st
 	return nil
 }
 
-// GetHostAddresses will return all possible ipadresses a host can get in the given prefix.
-// The IPs will be acquired by this method, so that the prefix has no free IPs afterwards.
-func (i *Ipamer) GetHostAddresses(prefix string) ([]string, error) {
+func (i *ipamer) GetHostAddresses(prefix string) ([]string, error) {
 	hostAddresses := []string{}
 
 	p, err := i.NewPrefix(prefix)
@@ -368,8 +352,8 @@ func (i *Ipamer) GetHostAddresses(prefix string) ([]string, error) {
 	}
 }
 
-// NewPrefix create a new Prefix from a string notation.
-func (i *Ipamer) newPrefix(cidr string) (*Prefix, error) {
+// newPrefix create a new Prefix from a string notation.
+func (i *ipamer) newPrefix(cidr string) (*Prefix, error) {
 	_, _, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse cidr:%s %v", cidr, err)
@@ -438,7 +422,7 @@ func (p *Prefix) Network() (net.IP, error) {
 	return ip.Mask(ipnet.Mask), nil
 }
 
-// Availableips return the number of ips available in this Prefix
+// availableips return the number of ips available in this Prefix
 func (p *Prefix) availableips() uint64 {
 	_, ipnet, err := net.ParseCIDR(p.Cidr)
 	if err != nil {
@@ -457,17 +441,17 @@ func (p *Prefix) availableips() uint64 {
 	return count
 }
 
-// Acquiredips return the number of ips acquired in this Prefix
+// acquiredips return the number of ips acquired in this Prefix
 func (p *Prefix) acquiredips() uint64 {
 	return uint64(len(p.ips))
 }
 
-// AvailablePrefixes return the amount of possible prefixes of this prefix if this is a parent prefix
+// availablePrefixes return the amount of possible prefixes of this prefix if this is a parent prefix
 func (p *Prefix) availablePrefixes() uint64 {
 	return uint64(len(p.availableChildPrefixes))
 }
 
-// AcquiredPrefixes return the amount of acquired prefixes of this prefix if this is a parent prefix
+// acquiredPrefixes return the amount of acquired prefixes of this prefix if this is a parent prefix
 func (p *Prefix) acquiredPrefixes() uint64 {
 	var count uint64
 	for _, available := range p.availableChildPrefixes {

--- a/prefix.go
+++ b/prefix.go
@@ -331,7 +331,9 @@ func (i *ipamer) PrefixesOverlapping(existingPrefixes []string, newPrefixes []st
 	return nil
 }
 
-func (i *ipamer) GetHostAddresses(prefix string) ([]string, error) {
+// getHostAddresses will return all possible ipadresses a host can get in the given prefix.
+// The IPs will be acquired by this method, so that the prefix has no free IPs afterwards.
+func (i *ipamer) getHostAddresses(prefix string) ([]string, error) {
 	hostAddresses := []string{}
 
 	p, err := i.NewPrefix(prefix)

--- a/prefix_benchmark_test.go
+++ b/prefix_benchmark_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func benchmarkNewPrefix(ipam *Ipamer, b *testing.B) {
+func benchmarkNewPrefix(ipam Ipamer, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		p, err := ipam.NewPrefix("192.168.0.0/24")
 		if err != nil {
@@ -34,7 +34,7 @@ func BenchmarkNewPrefixPostgres(b *testing.B) {
 	benchmarkNewPrefix(ipam, b)
 }
 
-func benchmarkAcquireIP(ipam *Ipamer, cidr string, b *testing.B) {
+func benchmarkAcquireIP(ipam Ipamer, cidr string, b *testing.B) {
 	p, err := ipam.NewPrefix(cidr)
 	if err != nil {
 		panic(err)

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -617,7 +617,7 @@ func TestIpamerAcquireIP(t *testing.T) {
 func TestGetHostAddresses(t *testing.T) {
 	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		cidr := "4.1.0.0/24"
-		ips, err := ipam.GetHostAddresses(cidr)
+		ips, err := ipam.getHostAddresses(cidr)
 		if err != nil {
 			panic(err)
 		}
@@ -632,7 +632,7 @@ func TestGetHostAddresses(t *testing.T) {
 		require.Nil(t, ip)
 
 		cidr = "3.1.0.0/26"
-		ips, err = ipam.GetHostAddresses(cidr)
+		ips, err = ipam.getHostAddresses(cidr)
 		if err != nil {
 			panic(err)
 		}

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -55,7 +55,7 @@ func TestIpamer_AcquireIP(t *testing.T) {
 	}
 	for _, tt := range tests {
 
-		testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+		testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 			p, err := ipam.NewPrefix(tt.fields.prefixCIDR)
 			if err != nil {
 				t.Errorf("Could not create prefix: %v", err)
@@ -85,7 +85,7 @@ func TestIpamer_AcquireIP(t *testing.T) {
 
 func TestIpamer_ReleaseIPFromPrefix(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/24")
 		require.Nil(t, err)
 		require.NotNil(t, prefix)
@@ -105,7 +105,7 @@ func TestIpamer_ReleaseIPFromPrefix(t *testing.T) {
 }
 
 func TestIpamer_AcquireSpecificIP(t *testing.T) {
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.99.0/24")
 		require.Nil(t, err)
 		require.Equal(t, prefix.availableips(), uint64(256))
@@ -160,7 +160,7 @@ func TestIpamer_AcquireSpecificIP(t *testing.T) {
 
 func TestIpamer_AcquireIPCounts(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/24")
 		require.Nil(t, err)
 		require.Equal(t, prefix.availableips(), uint64(256))
@@ -195,7 +195,7 @@ func TestIpamer_AcquireIPCounts(t *testing.T) {
 
 func TestIpamer_AcquireChildPrefixCounts(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		allPrefixes, err := ipam.storage.ReadAllPrefixes()
 		require.Nil(t, err)
 		require.Equal(t, 0, len(allPrefixes))
@@ -292,7 +292,7 @@ func TestIpamer_AcquireChildPrefixCounts(t *testing.T) {
 
 func TestIpamer_AcquireChildPrefix(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/20")
 		require.Nil(t, err)
 		require.Equal(t, prefix.availablePrefixes(), uint64(0))
@@ -363,7 +363,7 @@ func TestIpamer_AcquireChildPrefix(t *testing.T) {
 
 func TestIpamer_AcquireChildPrefixNoDuplicatesUntilFull(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/16")
 		require.Nil(t, err)
 		require.Equal(t, uint64(0), prefix.availablePrefixes())
@@ -481,7 +481,7 @@ func TestIpamer_PrefixesOverlapping(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+		testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 			for _, ep := range tt.existingPrefixes {
 				p, err := ipam.NewPrefix(ep)
 				if err != nil {
@@ -527,7 +527,7 @@ func TestIpamer_NewPrefix(t *testing.T) {
 	}
 	for _, tt := range tests {
 
-		testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+		testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 			got, err := ipam.NewPrefix(tt.cidr)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Ipamer.NewPrefix() error = %v, wantErr %v", err, tt.wantErr)
@@ -551,7 +551,7 @@ func TestIpamer_NewPrefix(t *testing.T) {
 
 func TestIpamer_DeletePrefix(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/20")
 		require.Nil(t, err)
 		require.Equal(t, prefix.availablePrefixes(), uint64(0))
@@ -570,7 +570,7 @@ func TestIpamer_DeletePrefix(t *testing.T) {
 
 func TestIpamer_PrefixFrom(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		prefix := ipam.PrefixFrom("192.168.0.0/20")
 		require.Nil(t, prefix)
 
@@ -585,7 +585,7 @@ func TestIpamer_PrefixFrom(t *testing.T) {
 
 func TestIpamerAcquireIP(t *testing.T) {
 
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		cidr := "10.0.0.0/16"
 		p, err := ipam.NewPrefix(cidr)
 		if err != nil {
@@ -615,7 +615,7 @@ func TestIpamerAcquireIP(t *testing.T) {
 }
 
 func TestGetHostAddresses(t *testing.T) {
-	testWithBackends(t, func(t *testing.T, ipam *Ipamer) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
 		cidr := "4.1.0.0/24"
 		ips, err := ipam.GetHostAddresses(cidr)
 		if err != nil {
@@ -708,7 +708,7 @@ func (e *ExtendedSQL) cleanup() error {
 	return tx.Commit()
 }
 
-type testMethod func(t *testing.T, ipam *Ipamer)
+type testMethod func(t *testing.T, ipam *ipamer)
 
 func testWithBackends(t *testing.T, fn testMethod) {
 	for _, storageProvider := range storageProviders() {
@@ -722,7 +722,8 @@ func testWithBackends(t *testing.T, fn testMethod) {
 			}
 		}
 
-		ipamer := NewWithStorage(storage)
+		//ipamer := NewWithStorage(storage)
+		ipamer := &ipamer{storage: storage}
 		testName := storageProvider.name
 
 		t.Run(testName, func(t *testing.T) {

--- a/sql_test.go
+++ b/sql_test.go
@@ -16,24 +16,24 @@ func Test_sql_prefixExists(t *testing.T) {
 
 	// Existing Prefix
 	prefix := Prefix{Cidr: "10.0.0.0/16"}
-	p, err := db.CreatePrefix(prefix)
+	p, err := db.CreatePrefix(nil, prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
 	require.Equal(t, prefix.Cidr, p.Cidr)
-	got, exists := db.prefixExists(prefix)
+	got, exists := db.prefixExists(nil, prefix)
 	require.True(t, exists)
 	require.Equal(t, got.Cidr, prefix.Cidr)
 
 	// NonExisting Prefix
 	notExistingPrefix := Prefix{Cidr: "10.0.0.0/8"}
-	got, exists = db.prefixExists(notExistingPrefix)
+	got, exists = db.prefixExists(nil, notExistingPrefix)
 	require.False(t, exists)
 	require.Nil(t, got)
 
 	// Delete Existing Prefix
-	_, err = db.DeletePrefix(prefix)
+	_, err = db.DeletePrefix(nil, prefix)
 	require.Nil(t, err)
-	got, exists = db.prefixExists(prefix)
+	got, exists = db.prefixExists(nil, prefix)
 	require.False(t, exists)
 	require.Nil(t, got)
 }
@@ -46,24 +46,24 @@ func Test_sql_CreatePrefix(t *testing.T) {
 
 	// Existing Prefix
 	prefix := Prefix{Cidr: "11.0.0.0/16"}
-	got, exists := db.prefixExists(prefix)
+	got, exists := db.prefixExists(nil, prefix)
 	require.False(t, exists)
 	require.Nil(t, got)
-	p, err := db.CreatePrefix(prefix)
+	p, err := db.CreatePrefix(nil, prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
 	require.Equal(t, prefix.Cidr, p.Cidr)
-	got, exists = db.prefixExists(prefix)
+	got, exists = db.prefixExists(nil, prefix)
 	require.True(t, exists)
 	require.Equal(t, got.Cidr, prefix.Cidr)
 
 	// Duplicate Prefix
-	p, err = db.CreatePrefix(prefix)
+	p, err = db.CreatePrefix(nil, prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
 	require.Equal(t, prefix.Cidr, p.Cidr)
 
-	ps, err := db.ReadAllPrefixes()
+	ps, err := db.ReadAllPrefixes(nil)
 	require.Nil(t, err)
 	require.NotNil(t, ps)
 	require.Equal(t, 1, len(ps))
@@ -76,17 +76,17 @@ func Test_sql_ReadPrefix(t *testing.T) {
 	require.NotNil(t, db)
 
 	// Prefix
-	p, err := db.ReadPrefix("12.0.0.0/8")
+	p, err := db.ReadPrefix(nil, "12.0.0.0/8")
 	require.NotNil(t, err)
 	require.Equal(t, "unable to read prefix:sql: no rows in result set", err.Error())
 	require.Empty(t, p)
 
 	prefix := Prefix{Cidr: "12.0.0.0/16"}
-	p, err = db.CreatePrefix(prefix)
+	p, err = db.CreatePrefix(nil, prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
 
-	p, err = db.ReadPrefix("12.0.0.0/16")
+	p, err = db.ReadPrefix(nil, "12.0.0.0/16")
 	require.Nil(t, err)
 	require.NotNil(t, p)
 	require.Equal(t, "12.0.0.0/16", p.Cidr)
@@ -99,25 +99,25 @@ func Test_sql_ReadAllPrefix(t *testing.T) {
 	require.NotNil(t, db)
 
 	// no Prefixes
-	ps, err := db.ReadAllPrefixes()
+	ps, err := db.ReadAllPrefixes(nil)
 	require.Nil(t, err)
 	require.NotNil(t, ps)
 	require.Equal(t, 0, len(ps))
 
 	// One Prefix
 	prefix := Prefix{Cidr: "12.0.0.0/16"}
-	p, err := db.CreatePrefix(prefix)
+	p, err := db.CreatePrefix(nil, prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
-	ps, err = db.ReadAllPrefixes()
+	ps, err = db.ReadAllPrefixes(nil)
 	require.Nil(t, err)
 	require.NotNil(t, ps)
 	require.Equal(t, 1, len(ps))
 
 	// no Prefixes again
-	_, err = db.DeletePrefix(prefix)
+	_, err = db.DeletePrefix(nil, prefix)
 	require.Nil(t, err)
-	ps, err = db.ReadAllPrefixes()
+	ps, err = db.ReadAllPrefixes(nil)
 	require.Nil(t, err)
 	require.NotNil(t, ps)
 	require.Equal(t, 0, len(ps))
@@ -131,12 +131,12 @@ func Test_sql_UpdatePrefix(t *testing.T) {
 
 	// Prefix
 	prefix := Prefix{Cidr: "13.0.0.0/16", ParentCidr: "13.0.0.0/8"}
-	p, err := db.CreatePrefix(prefix)
+	p, err := db.CreatePrefix(nil, prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
 
 	// Check if present
-	p, err = db.ReadPrefix("13.0.0.0/16")
+	p, err = db.ReadPrefix(nil, "13.0.0.0/16")
 	require.Nil(t, err)
 	require.NotNil(t, p)
 	require.Equal(t, "13.0.0.0/16", p.Cidr)
@@ -144,10 +144,10 @@ func Test_sql_UpdatePrefix(t *testing.T) {
 
 	// Modify
 	prefix.ParentCidr = "13.0.0.0/12"
-	p, err = db.UpdatePrefix(prefix)
+	p, err = db.UpdatePrefix(nil, prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
-	p, err = db.ReadPrefix("13.0.0.0/16")
+	p, err = db.ReadPrefix(nil, "13.0.0.0/16")
 	require.Nil(t, err)
 	require.NotNil(t, p)
 	require.Equal(t, "13.0.0.0/16", p.Cidr)

--- a/storage.go
+++ b/storage.go
@@ -2,11 +2,11 @@ package ipam
 
 // Storage is a interface to store ipam objects.
 type Storage interface {
-	CreatePrefix(prefix Prefix) (Prefix, error)
-	ReadPrefix(prefix string) (Prefix, error)
-	ReadAllPrefixes() ([]Prefix, error)
-	UpdatePrefix(prefix Prefix) (Prefix, error)
-	DeletePrefix(prefix Prefix) (Prefix, error)
+	CreatePrefix(namespace *string, prefix Prefix) (Prefix, error)
+	ReadPrefix(namespace *string, prefix string) (Prefix, error)
+	ReadAllPrefixes(namespace *string) ([]Prefix, error)
+	UpdatePrefix(namespace *string, prefix Prefix) (Prefix, error)
+	DeletePrefix(namespace *string, prefix Prefix) (Prefix, error)
 }
 
 // OptimisticLockError indicates that the operation could not be executed because the dataset to update has changed in the meantime.


### PR DESCRIPTION
requires #26 merged before.

Solves #25 by storing prefixes with a namespace prefix in the cidr column.

Bonus: add a unique UUID to every IP acquired, even if the same ip is released and acquired again, uuid will be different. @Gerrit91 for your specific use case.

TODO: more tests.