### PR TITLE
add a unique uuid to each IP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/avast/retry-go v2.6.0+incompatible
+	github.com/google/uuid v1.1.1
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.5.2
 	// sqlite v2.x is a unfortunate release

--- a/ip.go
+++ b/ip.go
@@ -10,6 +10,7 @@ import (
 type IP struct {
 	IP           net.IP
 	ParentPrefix string
+	UUID         string
 }
 
 func (i *IP) or(ip IP) IP {

--- a/prefix.go
+++ b/prefix.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -264,6 +265,7 @@ func (i *ipamer) acquireSpecificIPInternal(prefixCidr, specificIP string) (*IP, 
 			acquired = &IP{
 				IP:           ip,
 				ParentPrefix: prefix.Cidr,
+				UUID:         uuid.New().String(),
 			}
 			prefix.ips[ip.String()] = true
 			_, err := i.storage.UpdatePrefix(*prefix)


### PR DESCRIPTION
on every acquire even the same ip will have a unique uuid.
This will make it possible to identify if this ip belongs to the same entity as before and allows hardening deletion in upper levels such as metal-api.