### PR TITLE
expose json encoding/decoding of prefix

### DIFF
--- a/prefix_benchmark_test.go
+++ b/prefix_benchmark_test.go
@@ -134,3 +134,41 @@ func BenchmarkPrefixOverlapping(b *testing.B) {
 		}
 	}
 }
+func BenchmarkPrefixJSONDencoding(b *testing.B) {
+	prefix := &Prefix{
+		Cidr:                   "192.168.0.0/24",
+		availableChildPrefixes: map[string]bool{"192.168.128.0/25": true, "192.168.0.0/25": true},
+		ips:                    map[string]bool{"192.168.128.1": true, "192.168.0.2": true},
+		isParent:               true,
+		ParentCidr:             "",
+	}
+	data, err := prefix.JSONEncode()
+	if err != nil {
+		b.Errorf("encoding error:%w", err)
+	}
+	for n := 0; n < b.N; n++ {
+		newPrefix := &Prefix{}
+		err = newPrefix.JSONDecode(data)
+		if err != nil {
+			b.Errorf("decoding error:%w", err)
+		}
+		if prefix.Cidr != newPrefix.Cidr {
+			b.Errorf("%v != %v", prefix, newPrefix)
+		}
+	}
+}
+func BenchmarkPrefixJSONEncoding(b *testing.B) {
+	prefix := &Prefix{
+		Cidr:                   "192.168.0.0/24",
+		availableChildPrefixes: map[string]bool{"192.168.128.0/25": true, "192.168.0.0/25": true},
+		ips:                    map[string]bool{"192.168.128.1": true, "192.168.0.2": true},
+		isParent:               true,
+		ParentCidr:             "",
+	}
+	for n := 0; n < b.N; n++ {
+		_, err := prefix.JSONEncode()
+		if err != nil {
+			b.Errorf("encoding error:%w", err)
+		}
+	}
+}

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1206,3 +1206,19 @@ func TestPrefix_availablePrefixes(t *testing.T) {
 		})
 	}
 }
+
+func TestJSON(t *testing.T) {
+	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
+		prefix, err := ipam.NewPrefix("192.168.0.0/24")
+		require.Nil(t, err)
+		require.NotNil(t, prefix)
+
+		data, err := prefix.JSONEncode()
+		require.Nil(t, err)
+
+		newPrefix := &Prefix{}
+		err = newPrefix.JSONDecode(data)
+		require.Nil(t, err)
+		require.Equal(t, prefix, newPrefix)
+	})
+}

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1212,6 +1212,10 @@ func TestJSON(t *testing.T) {
 		prefix, err := ipam.NewPrefix("192.168.0.0/24")
 		require.Nil(t, err)
 		require.NotNil(t, prefix)
+		_, err = ipam.AcquireChildPrefix("192.168.0.0/24", 26)
+		require.Nil(t, err)
+		// reread
+		prefix = ipam.PrefixFrom("192.168.0.0/24")
 
 		data, err := prefix.JSONEncode()
 		require.Nil(t, err)


### PR DESCRIPTION
 to enable external users to implement storage, closes #15

Benchmark:
```
name                    old time/op    new time/op    delta
NewPrefixMemory-4         2.56µs ±15%    2.35µs ± 1%    ~     (p=0.690 n=5+5)
NewPrefixPostgres-4       10.4ms ± 4%     9.8ms ±20%    ~     (p=0.686 n=4+4)
NewPrefixCockroach-4      80.0ms ± 1%    78.4ms ± 6%    ~     (p=0.486 n=4+4)
AcquireIPMemory-4         4.37µs ±26%    4.12µs ± 5%    ~     (p=1.000 n=5+5)
AcquireIPPostgres-4       12.9ms ± 8%    14.6ms ±16%    ~     (p=0.095 n=5+5)
AcquireIPCockroach-4      83.9ms ± 5%    86.2ms ± 6%    ~     (p=0.310 n=5+5)
AcquireChildPrefix1-4     7.91µs ± 7%    8.48µs ± 7%    ~     (p=0.056 n=5+5)
AcquireChildPrefix2-4     8.83µs ±15%    7.95µs ± 4%    ~     (p=0.222 n=5+5)
AcquireChildPrefix3-4     8.64µs ± 9%    8.55µs ±21%    ~     (p=0.310 n=5+5)
AcquireChildPrefix4-4     8.43µs ± 7%    8.27µs ± 9%    ~     (p=0.690 n=5+5)
AcquireChildPrefix5-4     8.36µs ± 5%    8.34µs ± 7%    ~     (p=0.841 n=5+5)
AcquireChildPrefix6-4     7.72µs ± 1%    8.05µs ± 2%  +4.17%  (p=0.016 n=4+5)
AcquireChildPrefix7-4     8.40µs ± 8%    8.10µs ± 2%    ~     (p=0.310 n=5+5)
AcquireChildPrefix8-4     8.46µs ±12%    8.19µs ± 3%    ~     (p=0.690 n=5+5)
AcquireChildPrefix9-4     8.18µs ± 7%    8.52µs ± 9%    ~     (p=0.421 n=5+5)
AcquireChildPrefix10-4    7.79µs ± 1%    8.86µs ±31%    ~     (p=0.095 n=5+5)
PrefixOverlapping-4        359ns ± 2%     371ns ± 5%    ~     (p=0.341 n=5+5)

name                    old alloc/op   new alloc/op   delta
NewPrefixMemory-4         1.54kB ± 0%    1.54kB ± 0%    ~     (all equal)
NewPrefixPostgres-4       5.90kB ± 1%    5.77kB ± 1%  -2.19%  (p=0.029 n=4+4)
NewPrefixCockroach-4      7.43kB ± 2%    7.41kB ± 2%    ~     (p=1.000 n=4+4)
AcquireIPMemory-4         2.36kB ± 0%    2.36kB ± 0%    ~     (all equal)
AcquireIPPostgres-4       11.0kB ± 0%    10.8kB ± 1%  -1.40%  (p=0.008 n=5+5)
AcquireIPCockroach-4      12.8kB ± 1%    12.9kB ± 2%    ~     (p=0.841 n=5+5)
AcquireChildPrefix1-4     4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
AcquireChildPrefix2-4     4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
AcquireChildPrefix3-4     4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
AcquireChildPrefix4-4     4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
AcquireChildPrefix5-4     4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
AcquireChildPrefix6-4     4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
AcquireChildPrefix7-4     4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
AcquireChildPrefix8-4     4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
AcquireChildPrefix9-4     4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
AcquireChildPrefix10-4    4.50kB ± 0%    4.50kB ± 0%    ~     (all equal)
PrefixOverlapping-4        0.00B          0.00B         ~     (all equal)

name                    old allocs/op  new allocs/op  delta
NewPrefixMemory-4           20.0 ± 0%      20.0 ± 0%    ~     (all equal)
NewPrefixPostgres-4          128 ± 1%       128 ± 0%    ~     (p=1.000 n=4+4)
NewPrefixCockroach-4         145 ± 1%       146 ± 2%    ~     (p=0.771 n=4+4)
AcquireIPMemory-4           42.0 ± 0%      42.0 ± 0%    ~     (all equal)
AcquireIPPostgres-4          260 ± 0%       260 ± 1%    ~     (p=1.000 n=5+5)
AcquireIPCockroach-4         284 ± 1%       286 ± 1%    ~     (p=0.286 n=5+5)
AcquireChildPrefix1-4       69.0 ± 0%      69.0 ± 0%    ~     (all equal)
AcquireChildPrefix2-4       69.0 ± 0%      69.0 ± 0%    ~     (all equal)
AcquireChildPrefix3-4       69.0 ± 0%      69.0 ± 0%    ~     (all equal)
AcquireChildPrefix4-4       69.0 ± 0%      69.0 ± 0%    ~     (all equal)
AcquireChildPrefix5-4       69.0 ± 0%      69.0 ± 0%    ~     (all equal)
AcquireChildPrefix6-4       69.0 ± 0%      69.0 ± 0%    ~     (all equal)
AcquireChildPrefix7-4       69.0 ± 0%      69.0 ± 0%    ~     (all equal)
AcquireChildPrefix8-4       69.0 ± 0%      69.0 ± 0%    ~     (all equal)
AcquireChildPrefix9-4       69.0 ± 0%      69.0 ± 0%    ~     (all equal)
AcquireChildPrefix10-4      69.0 ± 0%      69.0 ± 0%    ~     (all equal)
PrefixOverlapping-4         0.00           0.00         ~     (all equal)
```