### PR TITLE
Ensure with a test that for normal prefixes parentcidr is empty

### DIFF
--- a/prefix_test.go
+++ b/prefix_test.go
@@ -867,13 +867,15 @@ func TestIpamer_NewPrefix(t *testing.T) {
 	tests := []struct {
 		name        string
 		cidr        string
+		parentCidr  string
 		wantErr     bool
 		errorString string
 	}{
 		{
-			name:    "valid Prefix",
-			cidr:    "192.168.0.0/24",
-			wantErr: false,
+			name:       "valid Prefix",
+			cidr:       "192.168.0.0/24",
+			parentCidr: "",
+			wantErr:    false,
 		},
 		{
 			name:        "invalid Prefix",
@@ -916,8 +918,11 @@ func TestIpamer_NewPrefix(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if !reflect.DeepEqual(got.Cidr, tt.cidr) {
+			if got.Cidr != tt.cidr {
 				t.Errorf("Ipamer.NewPrefix() = %v, want %v", got.Cidr, tt.cidr)
+			}
+			if got.ParentCidr != tt.parentCidr {
+				t.Errorf("Ipamer.NewPrefix() = %v, want %v", got.ParentCidr, tt.parentCidr)
 			}
 		})
 	}


### PR DESCRIPTION
Found a edgecase which was not covered by unit-tests, fix this.