### PR TITLE
fix handling of already allocated ipv6 prefix when requested directly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: build
-on: [push]
+on: [push, pull_request]
 jobs:
 
   build:


### PR DESCRIPTION
howdy :)

this fixes https://github.com/metal-stack/go-ipam/issues/47 although it changes behavior of `(i *ipamer) acquireSpecificIPInternal`.

- There is no silent fallback to dynamic allocation when an empty ip address string is passed. IMHO that helps to shadow buggy usage of this library, but I can re-add if wanted.
- if already in  use, a new error is returned: AlreadyAllocatedError

disclaimer: I have no idea how this affects the test pipeline because i could not get it running :/

WDYT?