### PR TITLE
postgres: Fix connection string

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -63,5 +63,6 @@ func newPostgres(host, port, user, password, dbname string, sslmode SSLMode) (*s
 }
 
 func dataSource(host, port, user, password, dbname string, sslmode SSLMode) string {
-	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?%s", user, password, host, port, dbname, sslmode)
+	return fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s %s",
+		host, user, password, dbname, port, sslmode)
 }


### PR DESCRIPTION
Usernames, Passwords and Database Names could in theory contain special characters - Secure passwords are highly likely to. With the current code, a password with special characters will result in the following error:

```console
$ docker run -d -e POSTGRES_USER="ad&min" -e POSTGRES_DB="ip@m" -e POSTGRES_PASSWORD="i.am<password>" -p 5432:5432 postgres
$ ./bin/server pg --password="i.am<password>" --host=localhost --user="ad&min" --dbname="ip@m"

2022/11/18 00:35:01 Error in cli: unable to connect to database:parse "postgres://ad&min:i.am<password>@localhost:5432/ip@m?sslmode=disable": net/url: invalid userinfo
```

This is because the current connection string is in URI format - to make this work those fields should be URL escaped.
A more compact approach is to use the connection string format shown in the sqlx [example](https://github.com/jmoiron/sqlx)
With this patch applied the connection will proceed successfully.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>