### PR TITLE
Fix postgres connection string

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -63,6 +63,5 @@ func newPostgres(host, port, user, password, dbname string, sslmode SSLMode) (*s
 }
 
 func dataSource(host, port, user, password, dbname string, sslmode SSLMode) string {
-	return fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s %s",
-		host, user, password, dbname, port, sslmode)
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?%s", user, password, host, port, dbname, sslmode)
 }

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -1,0 +1,86 @@
+package ipam
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatasource(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     string
+		user     string
+		password string
+		dbname   string
+		sslmode  SSLMode
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "basic, no escape",
+			host:     "host",
+			port:     "5432",
+			user:     "user",
+			password: "password",
+			dbname:   "dbname",
+			sslmode:  SSLModeAllow,
+			want:     "postgres://user:password@host:5432/dbname?sslmode=allow",
+			wantErr:  false,
+		},
+		{
+			name:     "username and password with escape chars",
+			host:     "host",
+			port:     "5432",
+			user:     "us@r",
+			password: "pass:word",
+			dbname:   "dbname",
+			sslmode:  SSLModeAllow,
+			want:     "postgres://us%40r:pass%3Aword@host:5432/dbname?sslmode=allow",
+			wantErr:  false,
+		},
+		{
+			name:     "spaces are not allowed in username/password",
+			host:     "host",
+			port:     "5432",
+			user:     "us er",
+			password: "pass word",
+			dbname:   "dbname",
+			sslmode:  SSLModeAllow,
+			want:     "",
+			wantErr:  true,
+		},
+		{
+			name:     "space allowed in dbname",
+			host:     "host",
+			port:     "5432",
+			user:     "user",
+			password: "password",
+			dbname:   "db name",
+			sslmode:  SSLModeAllow,
+			want:     "postgres://user:password@host:5432/db%20name?sslmode=allow",
+			wantErr:  false,
+		},
+		{
+			name:     "empty password",
+			host:     "host",
+			port:     "5432",
+			user:     "user",
+			password: "",
+			dbname:   "db name",
+			sslmode:  SSLModeAllow,
+			want:     "postgres://user:@host:5432/db%20name?sslmode=allow",
+			wantErr:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := dataSource(tc.host, tc.port, tc.user, tc.password, tc.dbname, tc.sslmode)
+			require.Equal(t, tc.wantErr, err != nil)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This addresses the bug [reported](https://github.com/metal-stack/go-ipam/pull/92#issuecomment-1432185190) on the previous changeset that moved from a URI to a PostgreSQL specific space-delimited connection string.

Since this `postgres` storage type is perfectly fine for usage with CockroachDB, I've opted to revert back to the URI format since CockroachDB does not support to support the single quote form described in the [libpq docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING). 

This change takes advantage of `net/url`'s ability to escape characters in a URL's userinfo.