### PR TITLE
postgres: Fix for complex passwords

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -70,7 +70,7 @@ func newPostgres(host, port, user, password, dbname string, sslmode SSLMode) (*s
 }
 
 func dataSource(host, port, user, password, dbname string, sslmode SSLMode) (string, error) {
-	baseURL := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?%s", user, password, host, port, dbname, sslmode)
+	baseURL := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?%s", url.PathEscape(user), url.PathEscape(password), host, port, dbname, sslmode)
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return "", fmt.Errorf("%w: unable to parse base URL:%s", err, baseURL)

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -41,15 +41,13 @@ func TestDatasource(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "spaces are not allowed in username/password",
-			host:     "host",
-			port:     "5432",
-			user:     "us er",
-			password: "pass word",
+			name:     "username and password with very special characters",
+			user:     "us@r",
+			password: "+S-@u]JBpWo^kduE7+(25zts",
 			dbname:   "dbname",
 			sslmode:  SSLModeAllow,
-			want:     "",
-			wantErr:  true,
+			want:     "postgres://us%40r:+S-%40u%5DJBpWo%5EkduE7+%2825zts@:/dbname?sslmode=allow",
+			wantErr:  false,
 		},
 		{
 			name:     "space allowed in dbname",
@@ -79,7 +77,11 @@ func TestDatasource(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := dataSource(tc.host, tc.port, tc.user, tc.password, tc.dbname, tc.sslmode)
-			require.Equal(t, tc.wantErr, err != nil)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
This adds a test case for complex passwords and adjusts the code to PathEscape both username and password before calling url.Parse

Fixes: #104 