### PR TITLE
Benchmark acquirespecificip to nail down performance problems

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.21
+    - name: Set up Go 1.22
       uses: actions/setup-go@v5
       with:
-        go-version: "1.21"
+        go-version: "1.22"
         cache: false
       id: go
 
@@ -89,10 +89,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.21
+    - name: Set up Go 1.22
       uses: actions/setup-go@v5
       with:
-        go-version: "1.21"
+        go-version: "1.22"
         cache: false
       id: go
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal-stack/go-ipam
 
-go 1.21
+go 1.22
 
 require (
 	connectrpc.com/connect v1.14.0

--- a/ipam_test.go
+++ b/ipam_test.go
@@ -34,7 +34,7 @@ func ExampleIpamer_NewPrefix() {
 	// Super Prefix  : 192.168.0.0/24
 	// Super Prefix IP1 : 192.168.0.1
 	// Super Prefix IP1 Parent : 192.168.0.0/24
-	// Super Prefix IP2 : 192.168.0.2
+	// Super Prefix IP2 : 192.168.0.254
 	// Super Prefix IP2 Parent : 192.168.0.0/24
 
 	_, err = ipamer.ReleaseIP(ctx, ip2)

--- a/json.go
+++ b/json.go
@@ -61,7 +61,7 @@ func (ps Prefixes) toJSON() ([]byte, error) {
 	for _, p := range ps {
 		pfxjs = append(pfxjs, p.toPrefixJSON())
 	}
-	pj, err := json.Marshal(pfxjs)
+	pj, err := json.Marshal(pfxjs) // nolint:musttag
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal prefixes:%w", err)
 	}
@@ -79,7 +79,7 @@ func fromJSON(js []byte) (Prefix, error) {
 
 func fromJSONs(js []byte) (Prefixes, error) {
 	var pres []prefixJSON
-	err := json.Unmarshal(js, &pres)
+	err := json.Unmarshal(js, &pres) // nolint:musttag
 	if err != nil {
 		return Prefixes{}, fmt.Errorf("unable to unmarshal prefixes:%w", err)
 	}

--- a/memory.go
+++ b/memory.go
@@ -33,7 +33,7 @@ func (m *memory) CreatePrefix(_ context.Context, prefix Prefix, namespace string
 	if ok {
 		return Prefix{}, fmt.Errorf("prefix already created:%v", prefix)
 	}
-	m.prefixes[namespace][prefix.Cidr] = *prefix.deepCopy()
+	m.prefixes[namespace][prefix.Cidr] = prefix
 	return prefix, nil
 }
 func (m *memory) ReadPrefix(_ context.Context, prefix, namespace string) (Prefix, error) {
@@ -107,7 +107,7 @@ func (m *memory) UpdatePrefix(_ context.Context, prefix Prefix, namespace string
 	if oldPrefix.version != oldVersion {
 		return Prefix{}, fmt.Errorf("%w: unable to update prefix:%s", ErrOptimisticLockError, prefix.Cidr)
 	}
-	m.prefixes[namespace][prefix.Cidr] = *prefix.deepCopy()
+	m.prefixes[namespace][prefix.Cidr] = prefix
 	return prefix, nil
 }
 func (m *memory) DeletePrefix(_ context.Context, prefix Prefix, namespace string) (Prefix, error) {
@@ -117,7 +117,7 @@ func (m *memory) DeletePrefix(_ context.Context, prefix Prefix, namespace string
 		return Prefix{}, ErrNamespaceDoesNotExist
 	}
 	delete(m.prefixes[namespace], prefix.Cidr)
-	return *prefix.deepCopy(), nil
+	return prefix, nil
 }
 
 func (m *memory) CreateNamespace(_ context.Context, namespace string) error {

--- a/prefix.go
+++ b/prefix.go
@@ -6,6 +6,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net/netip"
 	"strings"
@@ -36,8 +37,8 @@ func (p Prefix) deepCopy() *Prefix {
 		ParentCidr:             p.ParentCidr,
 		isParent:               p.isParent,
 		childPrefixLength:      p.childPrefixLength,
-		availableChildPrefixes: copyMap(p.availableChildPrefixes),
-		ips:                    copyMap(p.ips),
+		availableChildPrefixes: maps.Clone(p.availableChildPrefixes),
+		ips:                    maps.Clone(p.ips),
 		version:                p.version,
 	}
 }
@@ -93,15 +94,6 @@ func (p *Prefix) GobDecode(buf []byte) error {
 		return err
 	}
 	return decoder.Decode(&p.ParentCidr)
-}
-
-// TODO replace with maps.Copy
-func copyMap(m map[string]bool) map[string]bool {
-	cm := make(map[string]bool, len(m))
-	for k, v := range m {
-		cm[k] = v
-	}
-	return cm
 }
 
 // Usage of ips and child Prefixes of a Prefix

--- a/prefix.go
+++ b/prefix.go
@@ -375,11 +375,7 @@ func (i *ipamer) acquireSpecificIPInternal(ctx context.Context, namespace, prefi
 			continue
 		}
 
-		acquired, err := i.acquireAndStore(ctx, namespace, prefix, ip)
-		if err != nil {
-			return nil, err
-		}
-		return acquired, nil
+		return i.acquireAndStore(ctx, namespace, prefix, ip)
 	}
 
 	return nil, fmt.Errorf("%w: no more ips in prefix: %s left, length of prefix.ips: %d", ErrNoIPAvailable, prefix.Cidr, len(prefix.ips))

--- a/prefix.go
+++ b/prefix.go
@@ -372,6 +372,7 @@ func (i *ipamer) acquireSpecificIPInternal(ctx context.Context, namespace, prefi
 		if ok {
 			return nil, fmt.Errorf("%w: given ip:%s is already allocated", ErrAlreadyAllocated, specificIPnet)
 		}
+		return i.acquireAndStore(ctx, namespace, prefix, specificIPnet)
 	}
 
 	iprange := netipx.RangeOfPrefix(ipnet)
@@ -381,21 +382,28 @@ func (i *ipamer) acquireSpecificIPInternal(ctx context.Context, namespace, prefi
 		if ok {
 			continue
 		}
-		if specificIP == "" || specificIPnet.Compare(ip) == 0 {
-			acquired := &IP{
-				IP:           ip,
-				ParentPrefix: prefix.Cidr,
-			}
-			prefix.ips[ipstring] = true
-			_, err := i.storage.UpdatePrefix(ctx, *prefix, namespace)
-			if err != nil {
-				return nil, fmt.Errorf("unable to persist acquired ip:%v error:%w", prefix, err)
-			}
-			return acquired, nil
+
+		acquired, err := i.acquireAndStore(ctx, namespace, prefix, ip)
+		if err != nil {
+			return nil, err
 		}
+		return acquired, nil
 	}
 
 	return nil, fmt.Errorf("%w: no more ips in prefix: %s left, length of prefix.ips: %d", ErrNoIPAvailable, prefix.Cidr, len(prefix.ips))
+}
+
+func (i *ipamer) acquireAndStore(ctx context.Context, namespace string, prefix *Prefix, ip netip.Addr) (*IP, error) {
+	acquired := &IP{
+		IP:           ip,
+		ParentPrefix: prefix.Cidr,
+	}
+	prefix.ips[ip.String()] = true
+	_, err := i.storage.UpdatePrefix(ctx, *prefix, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to persist acquired ip:%v error:%w", prefix, err)
+	}
+	return acquired, nil
 }
 
 func (i *ipamer) AcquireIP(ctx context.Context, prefixCidr string) (*IP, error) {


### PR DESCRIPTION
#146 shows that ip allocation in prefixes with a lot of already allocated ips is slow.

This PR implements a Benchmark which shows this clearly:

```
 go test -benchmem -run=^$ -tags integration,client -memprofile memprofile.out -cpuprofile profile.out -bench ^BenchmarkAcquireSpecificIPInternal$ github.com/metal-stack/go-ipam
Using postgres:16-alpine cockroach:latest-v23.1 redis:7.2-alpine keydb:latest etcd:v3.5.10 mongodb:7
goos: linux
goarch: amd64
pkg: github.com/metal-stack/go-ipam
cpu: 12th Gen Intel(R) Core(TM) i7-1260P
BenchmarkAcquireSpecificIPInternal/empty_prefix-16                 10000            746019 ns/op          461410 B/op       5024 allocs/op
BenchmarkAcquireSpecificIPInternal/hundert_ips_allocated-16                10000            766130 ns/op          469745 B/op       5125 allocs/op
BenchmarkAcquireSpecificIPInternal/thousand_ips_allocated-16                3232            404067 ns/op          266595 B/op       2790 allocs/op
BenchmarkAcquireSpecificIPInternal/two_thousand_ips_allocated-16            1892            616107 ns/op          381988 B/op       4035 allocs/op
BenchmarkAcquireSpecificIPInternal/five_thousand_ips_allocated-16              1        1819201577 ns/op        1182815640 B/op 12581364 allocs/op
PASS
```

looking at the cpu profile, we can see that most of the time is spent in the deepcopy function of a prefix.

This is the cpu profile running this benchmark with an empty prefix:
![empty-prefix](https://github.com/metal-stack/go-ipam/assets/410110/6ab6d169-3323-42a9-915b-d0a02475a510)


And this shows the cpu profile with 5000 already allocated ips:
![fivethousend-ips-allocated](https://github.com/metal-stack/go-ipam/assets/410110/e85a9880-43d7-4d2b-8db9-f15d13d0fcff)


Graphs are  generated with:
```
go tool pprof profile.out
File: go-ipam.test
Type: cpu
Time: May 11, 2024 at 9:41am (CEST)
Duration: 23.68s, Total samples = 27.24s (115.04%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) web
```