### PR TITLE
More resilient child prefix release.

### DIFF
--- a/prefix.go
+++ b/prefix.go
@@ -304,14 +304,16 @@ func (i *ipamer) releaseChildPrefixInternal(ctx context.Context, namespace strin
 	}
 
 	parent.availableChildPrefixes[child.Cidr] = true
-	_, err = i.DeletePrefix(ctx, child.Cidr)
-	if err != nil {
-		return fmt.Errorf("unable to release prefix %v:%w", child, err)
-	}
 	_, err = i.storage.UpdatePrefix(ctx, *parent, namespace)
 	if err != nil {
 		return fmt.Errorf("unable to release prefix %v:%w", child, err)
 	}
+
+	_, err = i.DeletePrefix(ctx, child.Cidr)
+	if err != nil {
+		return fmt.Errorf("unable to release prefix %v:%w", child, err)
+	}
+
 	return nil
 }
 

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1761,7 +1761,7 @@ func TestReleaseChildPrefixParallel(t *testing.T) {
 	g, _ := errgroup.WithContext(context.Background())
 
 	testWithBackends(t, func(t *testing.T, ipam *ipamer) {
-		parent, err := ipam.NewPrefix(ctx, "192.168.0.0/16")
+		parent, err := ipam.NewPrefix(ctx, "192.168.0.0/14")
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Without swapping the parent prefix update function, the test results into: 

```
--- FAIL: TestReleaseChildPrefixParallel (4.42s)
    --- FAIL: TestReleaseChildPrefixParallel/Memory (0.20s)
        prefix_test.go:1789: 
            	Error Trace:	/home/runner/work/go-ipam/go-ipam/prefix_test.go:17[89](https://github.com/metal-stack/go-ipam/actions/runs/9938147069/job/27449979536#step:8:90)
            	            				/home/runner/work/go-ipam/go-ipam/testing_test.go:553
            	Error:      	Received unexpected error:
            	            	unable to release prefix 192.168.56.0/22:NotFound: unable to find prefix for cidr:1[92](https://github.com/metal-stack/go-ipam/actions/runs/9938147069/job/27449979536#step:8:93).168.56.0/22 error:NotFound prefix 192.168.56.0/22 not found
            	Test:       	TestReleaseChildPrefixParallel/Memory
    --- FAIL: TestReleaseChildPrefixParallel/File (0.31s)
        prefix_test.go:1789: 
            	Error Trace:	/home/runner/work/go-ipam/go-ipam/prefix_test.go:1789
            	            				/home/runner/work/go-ipam/go-ipam/testing_test.go:553
            	Error:      	Received unexpected error:
            	            	unable to release prefix 192.168.56.0/22:NotFound: unable to find prefix for cidr:192.168.56.0/22 error:NotFound prefix 192.168.56.0/22 not found
            	Test:       	TestReleaseChildPrefixParallel/File
    --- FAIL: TestReleaseChildPrefixParallel/Postgres (0.85s)
        prefix_test.go:1789: 
            	Error Trace:	/home/runner/work/go-ipam/go-ipam/prefix_test.go:1789
            	            				/home/runner/work/go-ipam/go-ipam/testing_test.go:553
            	Error:      	Received unexpected error:
            	            	unable to release prefix 192.168.56.0/22:NotFound: unable to find prefix for cidr:192.168.56.0/22 error:NotFound prefix 192.168.56.0/22 not found
            	Test:       	TestReleaseChildPrefixParallel/Postgres
    --- FAIL: TestReleaseChildPrefixParallel/Cockroach (1.07s)
        prefix_test.go:1789: 
            	Error Trace:	/home/runner/work/go-ipam/go-ipam/prefix_test.go:1789
            	            				/home/runner/work/go-ipam/go-ipam/testing_test.go:553
            	Error:      	Received unexpected error:
            	            	unable to release prefix 192.168.56.0/22:NotFound: unable to find prefix for cidr:192.168.56.0/22 error:NotFound prefix 192.168.56.0/22 not found
            	Test:       	TestReleaseChildPrefixParallel/Cockroach
    --- FAIL: TestReleaseChildPrefixParallel/Redis (0.38s)
        prefix_test.go:1789: 
            	Error Trace:	/home/runner/work/go-ipam/go-ipam/prefix_test.go:1789
            	            				/home/runner/work/go-ipam/go-ipam/testing_test.go:553
            	Error:      	Received unexpected error:
            	            	unable to release prefix 192.168.56.0/22:NotFound: unable to find prefix for cidr:192.168.56.0/22 error:NotFound prefix 192.168.56.0/22 not found
            	Test:       	TestReleaseChildPrefixParallel/Redis
    --- FAIL: TestReleaseChildPrefixParallel/Etcd (0.65s)
        prefix_test.go:1789: 
            	Error Trace:	/home/runner/work/go-ipam/go-ipam/prefix_test.go:1789
            	            				/home/runner/work/go-ipam/go-ipam/testing_test.go:553
            	Error:      	Received unexpected error:
            	            	unable to release prefix 192.168.56.0/22:NotFound: unable to find prefix for cidr:192.168.56.0/22 error:NotFound prefix 192.168.56.0/22 not found
            	Test:       	TestReleaseChildPrefixParallel/Etcd
    --- FAIL: TestReleaseChildPrefixParallel/KeyDB (0.39s)
        prefix_test.go:1789: 
            	Error Trace:	/home/runner/work/go-ipam/go-ipam/prefix_test.go:1789
            	            				/home/runner/work/go-ipam/go-ipam/testing_test.go:553
            	Error:      	Received unexpected error:
            	            	unable to release prefix 192.168.56.0/22:NotFound: unable to find prefix for cidr:192.168.56.0/22 error:NotFound prefix 192.168.56.0/22 not found
            	Test:       	TestReleaseChildPrefixParallel/KeyDB
    --- FAIL: TestReleaseChildPrefixParallel/MongoDB (0.47s)
        prefix_test.go:1789: 
            	Error Trace:	/home/runner/work/go-ipam/go-ipam/prefix_test.go:1789
            	            				/home/runner/work/go-ipam/go-ipam/testing_test.go:553
            	Error:      	Received unexpected error:
            	            	unable to release prefix 192.168.56.0/22:NotFound: unable to find prefix for cidr:192.168.56.0/22 error:NotFound prefix 192.168.56.0/22 not found
            	Test:       	TestReleaseChildPrefixParallel/MongoDB
FAIL
```

References #153.