### PR TITLE
Simplify logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/docker v27.1.2+incompatible // indirect
+	github.com/docker/docker v27.2.0+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -73,7 +73,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.55.0 // indirect
+	github.com/prometheus/common v0.56.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -102,8 +102,8 @@ require (
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/time v0.6.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20240823204242-4ba0660f739c // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240823204242-4ba0660f739c // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240827150818-7e3bb234dfed // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240827150818-7e3bb234dfed // indirect
 	google.golang.org/grpc v1.65.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v27.1.2+incompatible h1:AhGzR1xaQIy53qCkxARaFluI00WPGtXn0AJuoQsVYTY=
-github.com/docker/docker v27.1.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.2.0+incompatible h1:Rk9nIVdfH3+Vz4cyI/uhbINhEZ/oLmc+CBXmH6fbNk4=
+github.com/docker/docker v27.2.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -137,8 +137,8 @@ github.com/prometheus/client_golang v1.20.2 h1:5ctymQzZlyOON1666svgwn3s6IKWgfbjs
 github.com/prometheus/client_golang v1.20.2/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
-github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G1dc=
-github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
+github.com/prometheus/common v0.56.0 h1:UffReloqkBtvtQEYDg2s+uDPGRrJyC6vZWPGXf6OhPY=
+github.com/prometheus/common v0.56.0/go.mod h1:7uRPFSUTbfZWsJ7MHY56sqt7hLQu3bxXHDnNhl8E9qI=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/redis/go-redis/v9 v9.6.1 h1:HHDteefn6ZkTtY5fGUE8tj8uy85AHk6zP7CpzIAM0y4=
@@ -276,10 +276,10 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/genproto/googleapis/api v0.0.0-20240823204242-4ba0660f739c h1:e0zB268kOca6FbuJkYUGxfwG4DKFZG/8DLyv9Zv66cE=
-google.golang.org/genproto/googleapis/api v0.0.0-20240823204242-4ba0660f739c/go.mod h1:fO8wJzT2zbQbAjbIoos1285VfEIYKDDY+Dt+WpTkh6g=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240823204242-4ba0660f739c h1:Kqjm4WpoWvwhMPcrAczoTyMySQmYa9Wy2iL6Con4zn8=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240823204242-4ba0660f739c/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
+google.golang.org/genproto/googleapis/api v0.0.0-20240827150818-7e3bb234dfed h1:3RgNmBoI9MZhsj3QxC+AP/qQhNwpCLOvYDYYsFrhFt0=
+google.golang.org/genproto/googleapis/api v0.0.0-20240827150818-7e3bb234dfed/go.mod h1:OCdP9MfskevB/rbYvHTsXTtKC+3bHWajPdoKgjcYkfo=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240827150818-7e3bb234dfed h1:J6izYgfBXAI3xTKLgxzTmUltdYaLsuBxFCgDHWJ/eXg=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240827150818-7e3bb234dfed/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=
 google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=

--- a/pkg/service/ipam-service.go
+++ b/pkg/service/ipam-service.go
@@ -35,7 +35,6 @@ func (i *IPAMService) Version(context.Context, *connect.Request[v1.VersionReques
 }
 
 func (i *IPAMService) CreatePrefix(ctx context.Context, req *connect.Request[v1.CreatePrefixRequest]) (*connect.Response[v1.CreatePrefixResponse], error) {
-	i.log.Debug("createprefix", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
@@ -44,7 +43,6 @@ func (i *IPAMService) CreatePrefix(ctx context.Context, req *connect.Request[v1.
 		if errors.Is(err, goipam.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		i.log.Error("createprefix", "error", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	return connect.NewResponse(
@@ -57,7 +55,6 @@ func (i *IPAMService) CreatePrefix(ctx context.Context, req *connect.Request[v1.
 	), nil
 }
 func (i *IPAMService) DeletePrefix(ctx context.Context, req *connect.Request[v1.DeletePrefixRequest]) (*connect.Response[v1.DeletePrefixResponse], error) {
-	i.log.Debug("deleteprefix", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
@@ -66,7 +63,6 @@ func (i *IPAMService) DeletePrefix(ctx context.Context, req *connect.Request[v1.
 		if errors.Is(err, goipam.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		i.log.Error("deleteprefix", "error", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
@@ -80,7 +76,6 @@ func (i *IPAMService) DeletePrefix(ctx context.Context, req *connect.Request[v1.
 	), nil
 }
 func (i *IPAMService) GetPrefix(ctx context.Context, req *connect.Request[v1.GetPrefixRequest]) (*connect.Response[v1.GetPrefixResponse], error) {
-	i.log.Debug("getprefix", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
@@ -102,13 +97,11 @@ func (i *IPAMService) GetPrefix(ctx context.Context, req *connect.Request[v1.Get
 	), nil
 }
 func (i *IPAMService) ListPrefixes(ctx context.Context, req *connect.Request[v1.ListPrefixesRequest]) (*connect.Response[v1.ListPrefixesResponse], error) {
-	i.log.Debug("listprefixes", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
 	resp, err := i.ipamer.ReadAllPrefixCidrs(ctx)
 	if err != nil {
-		i.log.Error("listprefixes", "error", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
@@ -128,7 +121,6 @@ func (i *IPAMService) ListPrefixes(ctx context.Context, req *connect.Request[v1.
 }
 
 func (i *IPAMService) AcquireChildPrefix(ctx context.Context, req *connect.Request[v1.AcquireChildPrefixRequest]) (*connect.Response[v1.AcquireChildPrefixResponse], error) {
-	i.log.Debug("acquirechildprefix", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
@@ -145,13 +137,11 @@ func (i *IPAMService) AcquireChildPrefix(ctx context.Context, req *connect.Reque
 	if req.Msg.GetChildCidr() != "" {
 		resp, err = i.ipamer.AcquireSpecificChildPrefix(ctx, parentCidr, childCidr)
 		if err != nil {
-			i.log.Error("acquirechildprefix", "parent cidr", parentCidr, "child cidr", childCidr, "length", length, "error", err)
 			return nil, connect.NewError(connect.CodeInvalidArgument, err)
 		}
 	} else {
 		resp, err = i.ipamer.AcquireChildPrefix(ctx, parentCidr, uint8(length)) // nolint:gosec
 		if err != nil {
-			i.log.Error("acquirechildprefix", "parent cidr", parentCidr, "length", length, "error", err)
 			return nil, connect.NewError(connect.CodeInvalidArgument, err)
 		}
 	}
@@ -166,7 +156,6 @@ func (i *IPAMService) AcquireChildPrefix(ctx context.Context, req *connect.Reque
 }
 
 func (i *IPAMService) ReleaseChildPrefix(ctx context.Context, req *connect.Request[v1.ReleaseChildPrefixRequest]) (*connect.Response[v1.ReleaseChildPrefixResponse], error) {
-	i.log.Debug("releasechildprefix", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
@@ -175,13 +164,11 @@ func (i *IPAMService) ReleaseChildPrefix(ctx context.Context, req *connect.Reque
 		if errors.Is(err, goipam.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		i.log.Error("releasechildprefix", "error", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
 	err = i.ipamer.ReleaseChildPrefix(ctx, prefix)
 	if err != nil {
-		i.log.Error("releasechildprefix", "error", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	return connect.NewResponse(
@@ -194,7 +181,6 @@ func (i *IPAMService) ReleaseChildPrefix(ctx context.Context, req *connect.Reque
 	), nil
 }
 func (i *IPAMService) AcquireIP(ctx context.Context, req *connect.Request[v1.AcquireIPRequest]) (*connect.Response[v1.AcquireIPResponse], error) {
-	i.log.Debug("acquireip", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
@@ -203,7 +189,6 @@ func (i *IPAMService) AcquireIP(ctx context.Context, req *connect.Request[v1.Acq
 	if req.Msg.GetIp() != "" {
 		resp, err = i.ipamer.AcquireSpecificIP(ctx, req.Msg.GetPrefixCidr(), req.Msg.GetIp())
 		if err != nil {
-			i.log.Error("acquireip", "error", err)
 			if errors.Is(err, goipam.ErrAlreadyAllocated) {
 				return nil, connect.NewError(connect.CodeAlreadyExists, err)
 			}
@@ -215,7 +200,6 @@ func (i *IPAMService) AcquireIP(ctx context.Context, req *connect.Request[v1.Acq
 			if errors.Is(err, goipam.ErrNoIPAvailable) {
 				return nil, connect.NewError(connect.CodeNotFound, err)
 			}
-			i.log.Error("acquireip", "error", err)
 			return nil, connect.NewError(connect.CodeInvalidArgument, err)
 		}
 	}
@@ -229,13 +213,11 @@ func (i *IPAMService) AcquireIP(ctx context.Context, req *connect.Request[v1.Acq
 	), nil
 }
 func (i *IPAMService) ReleaseIP(ctx context.Context, req *connect.Request[v1.ReleaseIPRequest]) (*connect.Response[v1.ReleaseIPResponse], error) {
-	i.log.Debug("releaseip", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
 	netip, err := netip.ParseAddr(req.Msg.GetIp())
 	if err != nil {
-		i.log.Error("releaseip", "error", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	ip := &goipam.IP{
@@ -244,7 +226,6 @@ func (i *IPAMService) ReleaseIP(ctx context.Context, req *connect.Request[v1.Rel
 	}
 	resp, err := i.ipamer.ReleaseIP(ctx, ip)
 	if err != nil {
-		i.log.Error("releaseip", "error", err)
 		if errors.Is(err, goipam.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
@@ -260,13 +241,11 @@ func (i *IPAMService) ReleaseIP(ctx context.Context, req *connect.Request[v1.Rel
 	), nil
 }
 func (i *IPAMService) Dump(ctx context.Context, req *connect.Request[v1.DumpRequest]) (*connect.Response[v1.DumpResponse], error) {
-	i.log.Debug("dump", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
 	dump, err := i.ipamer.Dump(ctx)
 	if err != nil {
-		i.log.Error("dump", "error", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	return connect.NewResponse(
@@ -277,19 +256,16 @@ func (i *IPAMService) Dump(ctx context.Context, req *connect.Request[v1.DumpRequ
 }
 
 func (i *IPAMService) Load(ctx context.Context, req *connect.Request[v1.LoadRequest]) (*connect.Response[v1.LoadResponse], error) {
-	i.log.Debug("load", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
 	err := i.ipamer.Load(ctx, req.Msg.GetDump())
 	if err != nil {
-		i.log.Error("load", "error", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	return connect.NewResponse(&v1.LoadResponse{}), nil
 }
 func (i *IPAMService) PrefixUsage(ctx context.Context, req *connect.Request[v1.PrefixUsageRequest]) (*connect.Response[v1.PrefixUsageResponse], error) {
-	i.log.Debug("prefixusage", "req", req)
 	if req.Msg.GetNamespace() != "" {
 		ctx = goipam.NewContextWithNamespace(ctx, req.Msg.GetNamespace())
 	}
@@ -298,7 +274,6 @@ func (i *IPAMService) PrefixUsage(ctx context.Context, req *connect.Request[v1.P
 		if errors.Is(err, goipam.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
-		i.log.Error("prefixusage", "error", err)
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	u := p.Usage()
@@ -314,7 +289,6 @@ func (i *IPAMService) PrefixUsage(ctx context.Context, req *connect.Request[v1.P
 }
 
 func (i *IPAMService) CreateNamespace(ctx context.Context, req *connect.Request[v1.CreateNamespaceRequest]) (*connect.Response[v1.CreateNamespaceResponse], error) {
-	i.log.Debug("createnamespace", "req", req)
 	err := i.ipamer.CreateNamespace(ctx, req.Msg.GetNamespace())
 	if err != nil {
 		return nil, err
@@ -323,7 +297,6 @@ func (i *IPAMService) CreateNamespace(ctx context.Context, req *connect.Request[
 }
 
 func (i *IPAMService) DeleteNamespace(ctx context.Context, req *connect.Request[v1.DeleteNamespaceRequest]) (*connect.Response[v1.DeleteNamespaceResponse], error) {
-	i.log.Debug("deletenamespace", "req", req)
 	err := i.ipamer.DeleteNamespace(ctx, req.Msg.GetNamespace())
 	if err != nil {
 		return nil, err
@@ -332,7 +305,6 @@ func (i *IPAMService) DeleteNamespace(ctx context.Context, req *connect.Request[
 }
 
 func (i *IPAMService) ListNamespaces(ctx context.Context, req *connect.Request[v1.ListNamespacesRequest]) (*connect.Response[v1.ListNamespacesResponse], error) {
-	i.log.Debug("", "req", req)
 	res, err := i.ipamer.ListNamespaces(ctx)
 	if err != nil {
 		return nil, err

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS += --no-print-directory
-BUF_VERSION := 1.38.0
+BUF_VERSION := 1.39.0
 
 _buf:
 	docker run --rm \


### PR DESCRIPTION
Put logging of the grpc service into one place in a interceptor. This will remove all manually created log entries and covers all requests, including response and errors.