### PR TITLE
Use existing context where possible

### DIFF
--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -44,7 +43,7 @@ func main() {
 						},
 						Action: func(ctx *cli.Context) error {
 							c := client(ctx)
-							result, err := c.CreatePrefix(context.Background(), &v1.CreatePrefixRequest{
+							result, err := c.CreatePrefix(ctx.Context, &v1.CreatePrefixRequest{
 								Cidr: ctx.String("cidr"),
 							})
 
@@ -68,7 +67,7 @@ func main() {
 						},
 						Action: func(ctx *cli.Context) error {
 							c := client(ctx)
-							result, err := c.AcquireChildPrefix(context.Background(), &v1.AcquireChildPrefixRequest{
+							result, err := c.AcquireChildPrefix(ctx.Context, &v1.AcquireChildPrefixRequest{
 								Cidr:   ctx.String("parent"),
 								Length: uint32(ctx.Uint("length")), // nolint:gosec
 							})
@@ -90,7 +89,7 @@ func main() {
 						},
 						Action: func(ctx *cli.Context) error {
 							c := client(ctx)
-							result, err := c.ReleaseChildPrefix(context.Background(), &v1.ReleaseChildPrefixRequest{
+							result, err := c.ReleaseChildPrefix(ctx.Context, &v1.ReleaseChildPrefixRequest{
 								Cidr: ctx.String("cidr"),
 							})
 
@@ -109,7 +108,7 @@ func main() {
 						Usage: "list all prefixes",
 						Action: func(ctx *cli.Context) error {
 							c := client(ctx)
-							result, err := c.ListPrefixes(context.Background(), &v1.ListPrefixesRequest{})
+							result, err := c.ListPrefixes(ctx.Context, &v1.ListPrefixesRequest{})
 
 							if err != nil {
 								return err
@@ -130,7 +129,7 @@ func main() {
 						},
 						Action: func(ctx *cli.Context) error {
 							c := client(ctx)
-							result, err := c.DeletePrefix(context.Background(), &v1.DeletePrefixRequest{
+							result, err := c.DeletePrefix(ctx.Context, &v1.DeletePrefixRequest{
 								Cidr: ctx.String("cidr"),
 							})
 
@@ -158,7 +157,7 @@ func main() {
 						},
 						Action: func(ctx *cli.Context) error {
 							c := client(ctx)
-							result, err := c.AcquireIP(context.Background(), &v1.AcquireIPRequest{
+							result, err := c.AcquireIP(ctx.Context, &v1.AcquireIPRequest{
 								PrefixCidr: ctx.String("prefix"),
 							})
 
@@ -182,7 +181,7 @@ func main() {
 						},
 						Action: func(ctx *cli.Context) error {
 							c := client(ctx)
-							result, err := c.ReleaseIP(context.Background(), &v1.ReleaseIPRequest{
+							result, err := c.ReleaseIP(ctx.Context, &v1.ReleaseIPRequest{
 								Ip:         ctx.String("ip"),
 								PrefixCidr: ctx.String("prefix"),
 							})
@@ -205,7 +204,7 @@ func main() {
 						Usage: "create a json file of the whole ipam db for backup purpose",
 						Action: func(ctx *cli.Context) error {
 							c := client(ctx)
-							result, err := c.Dump(context.Background(), &v1.DumpRequest{})
+							result, err := c.Dump(ctx.Context, &v1.DumpRequest{})
 							if err != nil {
 								return err
 							}
@@ -227,7 +226,7 @@ func main() {
 							if err != nil {
 								return err
 							}
-							_, err = c.Load(context.Background(), &v1.LoadRequest{
+							_, err = c.Load(ctx.Context, &v1.LoadRequest{
 								Dump: string(json),
 							})
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"log/slog"
@@ -281,7 +280,7 @@ func main() {
 						DatabaseName:       dbname,
 						MongoClientOptions: opts,
 					}
-					db, err := goipam.NewMongo(context.Background(), mongocfg)
+					db, err := goipam.NewMongo(ctx.Context, mongocfg)
 					if err != nil {
 						return err
 					}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -124,6 +124,7 @@ func (s *server) Run() error {
 	server := http.Server{
 		Addr:              s.c.GrpcServerEndpoint,
 		ReadHeaderTimeout: 1 * time.Minute,
+		Handler:           mux,
 	}
 	server.Protocols = new(http.Protocols)
 	server.Protocols.SetHTTP1(true)

--- a/pkg/service/ipam-service_test.go
+++ b/pkg/service/ipam-service_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -22,7 +21,7 @@ func TestIpamService(t *testing.T) {
 	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	mux := http.NewServeMux()
 	mux.Handle(apiv1connect.NewIpamServiceHandler(
-		New(log, goipam.New(context.Background())),
+		New(log, goipam.New(t.Context())),
 	))
 	server := httptest.NewUnstartedServer(mux)
 	server.EnableHTTP2 = true

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1655,12 +1655,12 @@ func TestNamespaceFromContext(t *testing.T) {
 		},
 		{
 			name: "namespaced context",
-			ctx:  NewContextWithNamespace(context.Background(), "a"),
+			ctx:  NewContextWithNamespace(t.Context(), "a"),
 			want: "a",
 		},
 		{
 			name: "invalid context value",
-			ctx:  context.WithValue(context.Background(), namespaceContextKey{}, true),
+			ctx:  context.WithValue(t.Context(), namespaceContextKey{}, true),
 			want: defaultNamespace,
 		},
 	}

--- a/sql_test.go
+++ b/sql_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_sql_prefixExists(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testWithSQLBackends(t, func(t *testing.T, db *sql) {
 		require.NotNil(t, db)
 
@@ -40,7 +40,7 @@ func Test_sql_prefixExists(t *testing.T) {
 }
 
 func Test_sql_CreatePrefix(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testWithSQLBackends(t, func(t *testing.T, db *sql) {
 		require.NotNil(t, db)
 
@@ -71,7 +71,7 @@ func Test_sql_CreatePrefix(t *testing.T) {
 }
 
 func Test_sql_ReadPrefix(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testWithSQLBackends(t, func(t *testing.T, db *sql) {
 		require.NotNil(t, db)
 
@@ -99,7 +99,7 @@ func Test_sql_ReadPrefix(t *testing.T) {
 }
 
 func Test_sql_ReadAllPrefix(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testWithSQLBackends(t, func(t *testing.T, db *sql) {
 		require.NotNil(t, db)
 
@@ -130,7 +130,7 @@ func Test_sql_ReadAllPrefix(t *testing.T) {
 }
 
 func Test_sql_CreateNamespace(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testWithSQLBackends(t, func(t *testing.T, db *sql) {
 		require.NotNil(t, db)
 		{
@@ -162,7 +162,7 @@ func Test_sql_CreateNamespace(t *testing.T) {
 }
 
 func Test_ConcurrentAcquirePrefix(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testWithSQLBackends(t, func(t *testing.T, db *sql) {
 		require.NotNil(t, db)
 
@@ -208,7 +208,7 @@ func acquirePrefix(t *testing.T, ctx context.Context, db *sql, cidr string, pref
 }
 
 func Test_ConcurrentAcquireIP(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testWithSQLBackends(t, func(t *testing.T, db *sql) {
 		require.NotNil(t, db)
 

--- a/testing_test.go
+++ b/testing_test.go
@@ -317,12 +317,12 @@ func startKeyDB(ctx context.Context) (container testcontainers.Container, s *red
 
 // cleanable interface for impls that support cleaning before each testrun
 type cleanable interface {
-	cleanup() error
+	cleanup(context.Context) error
 }
 
 // postCleanable interface for impls that support cleaning after each testrun
 type postCleanable interface {
-	postCleanup() error
+	postCleanup(context.Context) error
 }
 
 // extendedSQL extended sql interface
@@ -346,8 +346,7 @@ type docStorage struct {
 	c testcontainers.Container
 }
 
-func newLocalFileWithCleanup() (*file, error) {
-	ctx := context.Background()
+func newLocalFileWithCleanup(ctx context.Context) (*file, error) {
 	fp, err := os.CreateTemp("", "go-ipam-*.json")
 
 	if err != nil {
@@ -448,8 +447,8 @@ func newMongodbWithCleanup(ctx context.Context) (*docStorage, error) {
 	return x, nil
 }
 
-func (f *file) cleanup() error {
-	if err := f.clearParent(context.Background()); err != nil {
+func (f *file) cleanup(ctx context.Context) error {
+	if err := f.clearParent(ctx); err != nil {
 		return err
 	}
 	if _, err := os.Stat(f.path); errors.Is(err, fs.ErrNotExist) {
@@ -458,12 +457,12 @@ func (f *file) cleanup() error {
 	return os.Remove(f.path)
 }
 
-func (f *file) postCleanup() error {
-	return f.cleanup()
+func (f *file) postCleanup(ctx context.Context) error {
+	return f.cleanup(ctx)
 }
 
 // cleanup database before test
-func (e *extendedSQL) cleanup() error {
+func (e *extendedSQL) cleanup(ctx context.Context) error {
 	tx := e.db.MustBegin()
 	_, err := e.db.Exec("TRUNCATE TABLE prefixes")
 	if err != nil {
@@ -473,13 +472,13 @@ func (e *extendedSQL) cleanup() error {
 }
 
 // cleanup database before test
-func (kv *kvStorage) cleanup() error {
-	return kv.DeleteAllPrefixes(context.Background(), defaultNamespace)
+func (kv *kvStorage) cleanup(ctx context.Context) error {
+	return kv.DeleteAllPrefixes(ctx, defaultNamespace)
 }
 
 // cleanup database before test
-func (kv *kvEtcdStorage) cleanup() error {
-	return kv.DeleteAllPrefixes(context.Background(), defaultNamespace)
+func (kv *kvEtcdStorage) cleanup(ctx context.Context) error {
+	return kv.DeleteAllPrefixes(ctx, defaultNamespace)
 }
 
 // cleanup database before test
@@ -492,8 +491,8 @@ func (sql *sql) cleanup() error {
 	return tx.Commit()
 }
 
-func (ds *docStorage) cleanup() error {
-	return ds.DeleteAllPrefixes(context.Background(), defaultNamespace)
+func (ds *docStorage) cleanup(ctx context.Context) error {
+	return ds.DeleteAllPrefixes(ctx, defaultNamespace)
 }
 
 type benchMethod func(b *testing.B, ipam *ipamer)
@@ -506,7 +505,7 @@ func benchWithBackends(b *testing.B, fn benchMethod) {
 		storage := storageProvider.provide()
 
 		if tp, ok := storage.(cleanable); ok {
-			err := tp.cleanup()
+			err := tp.cleanup(b.Context())
 			if err != nil {
 				b.Errorf("error cleaning up before the test: %v", err)
 			}
@@ -520,7 +519,7 @@ func benchWithBackends(b *testing.B, fn benchMethod) {
 		})
 
 		if tp, ok := storage.(postCleanable); ok {
-			err := tp.postCleanup()
+			err := tp.postCleanup(b.Context())
 			if err != nil {
 				b.Errorf("error cleaning up after the test: %v", err)
 			}
@@ -540,7 +539,7 @@ func testWithBackends(t *testing.T, fn testMethod) {
 		storage := storageProvider.provide()
 
 		if tp, ok := storage.(cleanable); ok {
-			err := tp.cleanup()
+			err := tp.cleanup(t.Context())
 			if err != nil {
 				t.Errorf("error cleaning up, %v", err)
 			}
@@ -554,7 +553,7 @@ func testWithBackends(t *testing.T, fn testMethod) {
 		})
 
 		if tp, ok := storage.(postCleanable); ok {
-			err := tp.postCleanup()
+			err := tp.postCleanup(t.Context())
 			if err != nil {
 				t.Errorf("error cleaning up after the test: %v", err)
 			}
@@ -613,7 +612,7 @@ func storageProviders(ctx context.Context) []storageProvider {
 		{
 			name: "File",
 			provide: func() Storage {
-				storage, err := newLocalFileWithCleanup()
+				storage, err := newLocalFileWithCleanup(ctx)
 				if err != nil {
 					panic("error getting local file storage")
 				}


### PR DESCRIPTION
## Description

Cleanup context handling in tests and client.

Also contains a important fix to the http2 startup to include the mux handler :-)

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
