### PR TITLE
Remove grpc health probe from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,9 @@
-FROM alpine:3.23 AS health-downloader
-ENV GRPC_HEALTH_PROBE_VERSION=v0.4.47 \
-    GRPC_HEALTH_PROBE_URL=https://github.com/grpc-ecosystem/grpc-health-probe/releases/download
-RUN apk add curl \
- && curl -fLso /bin/grpc_health_probe \
-    ${GRPC_HEALTH_PROBE_URL}/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 \
- && chmod +x /bin/grpc_health_probe
- 
-FROM golang:1.26-alpine AS builder
-RUN apk add \
-    binutils \
-    gcc \
-    git \
-    libc-dev \
-    make
+FROM golang:1.26-trixie AS builder
 
 WORKDIR /work
 COPY . .
 RUN make server client
 
 FROM gcr.io/distroless/static-debian13:nonroot
-COPY --from=health-downloader /bin/grpc_health_probe /bin/grpc_health_probe
 COPY --from=builder /work/bin/* /
 ENTRYPOINT [ "/server" ]


### PR DESCRIPTION
## Description

Because since k8s v1.27 grpc probes are natively supported.
Reduces image from 20MB -> 16MB


Depends on 
- [x] https://github.com/metal-stack/helm-charts/pull/158 to be released

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
